### PR TITLE
feat: implement a serial console into the flashtool

### DIFF
--- a/.changeset/empty-rats-help.md
+++ b/.changeset/empty-rats-help.md
@@ -1,0 +1,5 @@
+---
+'frontend': minor
+---
+
+Added a serial terminal to the web flashtool.

--- a/src/lib/EspTool/FlashManager.ts
+++ b/src/lib/EspTool/FlashManager.ts
@@ -8,68 +8,258 @@ import {
 import HashMD5 from 'crypto-js/md5';
 import Latin1 from 'crypto-js/enc-latin1';
 
+/**
+ * Reboots the chip in ESPLoader mode.
+ */
+async function setupESPLoader(serialPort: SerialPort, terminal: IEspLoaderTerminal): Promise<ESPLoader | null> {
+  try {
+    await serialPort.close(); // TODO: Find some way to detect if the port is already open
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    /* empty */
+  }
+
+  try {
+    console.log('setupESPLoader: ', serialPort);
+    const transport = new Transport(serialPort);
+
+    const flashOptions = {
+      transport,
+      baudrate: 115200,
+      terminal,
+    } as LoaderOptions;
+
+    const loader = new ESPLoader(flashOptions);
+
+    await loader.main();
+
+    return loader;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((f) => setTimeout(f, ms));
+}
+
+/**
+ * Reboots the chip in application mode.
+ */
+async function setupApplication(serialPort: SerialPort): Promise<SerialPort | null> {
+  try {
+    await serialPort.close(); // TODO: Find some way to detect if the port is already open
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    /* empty */
+  }
+
+  try {
+    console.log('setupApplication: ', serialPort);
+
+    // Need to connect to the ESP32 using the right settings.
+    // Hardware flow control would be a disaster, as these pins are used to control the device's bootloader.
+    // https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/boot-mode-selection.html
+    await serialPort.open({
+      baudRate: 115200,
+      dataBits: 8,
+      parity: "none",
+      flowControl: "none"
+    });
+
+    // give it time
+    await sleep(200);
+
+    // tell the chip to reset
+    await serialPort.setSignals({
+      dataTerminalReady: false,
+      requestToSend: true
+    });
+
+    // give it more time
+    await sleep(200);
+
+    await serialPort.setSignals({
+      dataTerminalReady: false,
+      requestToSend: false
+    });
+
+    // give it even more time to actually boot
+    await sleep(200);
+
+    return serialPort;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+/**
+ * FlashManager ; manages flashing the device.
+ * Beware that operations on FlashManager are not atomic (they never were, I've just noted this down now)
+ */
 export default class FlashManager {
-  private transport: Transport | null;
+  /**
+   * Underlying serial port wrapper. null if the FlashManager has been disconnect()ed.
+   */
+  private serialPort: SerialPort | null;
+  /**
+   * Active reader in app mode.
+   */
+  private serialPortReader: ReadableStreamDefaultReader<Uint8Array> | null;
+  /**
+   * Active writer in app mode, if any.
+   */
+  private serialPortWriter: WritableStreamDefaultWriter<Uint8Array> | null;
+  /**
+   * Loader: ESPLoader. Presence or lack thereof indicates if the target device is in bootloader mode.
+   */
   private loader: ESPLoader | null;
+  /**
+   * Terminal: Shared output terminal between ESPLoader and firmware output.
+   */
   private terminal: IEspLoaderTerminal;
+  /**
+   * Chip: During connect, the chip is read from the ESPLoader.
+   */
   private chip: string;
 
   private constructor(
-    transport: Transport,
     loader: ESPLoader,
-    terminal: IEspLoaderTerminal,
-    chip: string
+    terminal: IEspLoaderTerminal
   ) {
-    this.transport = transport;
+    this.serialPort = loader.transport.device;
     this.loader = loader;
     this.terminal = terminal;
-    this.chip = chip;
+    this.chip = loader.chip.CHIP_NAME;
   }
 
   static async Connect(serialPort: SerialPort, terminal: IEspLoaderTerminal) {
-    try {
-      await serialPort.close(); // TODO: Find some way to detect if the port is already open
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
-      /* empty */
-    }
-
-    try {
-      console.log('Connecting to', serialPort);
-      const transport = new Transport(serialPort);
-
-      const flashOptions = {
-        transport,
-        baudrate: 115200,
-        terminal,
-      } as LoaderOptions;
-
-      const loader = new ESPLoader(flashOptions);
-
-      const chip = await loader.main();
-
-      return new FlashManager(transport, loader, terminal, chip);
-    } catch (e) {
-      console.error(e);
+    let espLoader = await setupESPLoader(serialPort, terminal);
+    if (espLoader != null) {
+      return new FlashManager(espLoader, terminal);
+    } else {
       return null;
     }
   }
 
   get SerialPort() {
-    return this.transport?.device ?? null;
+    return this.serialPort;
   }
 
   get Chip() {
     return this.chip;
   }
 
+  /**
+   * Assumes the FlashManager is connected.
+   * To work around esptool.js issues (namely, any timeout whatsoever corrupts newRead and probably everything else too), some operations have to 'reboot' the transport.
+   * In addition, to reduce any weirdness, the FlashManager becomes 'disconnected' while it is switching states.
+   */
+  private async _cycleTransport(): Promise<SerialPort> {
+    let loader = this.loader;
+    let serialPort = this.serialPort!;
+    let serialPortReader = this.serialPortReader;
+    let serialPortWriter = this.serialPortWriter;
+    this.serialPort = null;
+    this.serialPortReader = null;
+    this.serialPortWriter = null;
+    this.loader = null;
+    if (loader) {
+      try {
+        await loader.transport!.disconnect();
+      } catch {
+        // try to shut everything off, silently fail
+      }
+    }
+    if (serialPortReader) {
+      try {
+        await serialPortReader.cancel();
+      } catch {
+          // try to shut everything off, silently fail
+      }
+    }
+    if (serialPortWriter) {
+      try {
+        await serialPortWriter.close();
+      } catch {
+          // try to shut everything off, silently fail
+      }
+    }
+    try {
+      await serialPort.close();
+    } catch {
+        // try to shut everything off, silently fail
+    }
+    return serialPort;
+  }
+
+  async ensureBootloader(forceReset?: boolean) {
+    if (!this.serialPort) return false;
+    if (this.loader && !forceReset) return true;
+
+    let serialPort = await this._cycleTransport();
+
+    let loader = await setupESPLoader(serialPort, this.terminal);
+    if (loader) {
+      // success (if a failure occurs we're left disconnected)
+      this.serialPort = serialPort;
+      this.loader = loader;
+      this.chip = loader.chip.CHIP_NAME;
+    }
+  }
+
+  async ensureApplication(forceReset?: boolean) {
+    if (!this.serialPort) return false;
+    if ((!this.loader) && !forceReset) return true;
+
+    let serialPort = await setupApplication(await this._cycleTransport());
+    this.serialPort = serialPort;
+
+    if (serialPort) {
+      let serialPortReader = serialPort!.readable!.getReader();
+      let serialPortWriter = serialPort!.writable!.getWriter();
+      this.serialPortReader = serialPortReader;
+      this.serialPortWriter = serialPortWriter;
+      // connect application to terminal
+      (async () => {
+        try {
+          let lineBuffer = [];
+          while (true) {
+            // since we're using Transport APIs, and since they have no "no timeout" option, get as close as possible
+            let b = await serialPortReader.read();
+            if (b.done)
+              break;
+            if (b.value) {
+              for (let byte of b.value) {
+                // next byte
+                if (byte == 13) continue;
+                if (byte == 10) {
+                  // write out line
+                  this.terminal.writeLine(new TextDecoder().decode(new Uint8Array(lineBuffer)));
+                  lineBuffer = [];
+                } else {
+                  lineBuffer.push(byte);
+                }
+              }
+            } else {
+              // if the port somehow returns all zero length buffers or something...
+              await sleep(1);
+            }
+          }
+        } catch (e) {
+          console.log(e);
+          this.terminal.writeLine(`firmware disconnected: ${e}`);
+        }
+      })();
+    }
+  }
+
   async disconnect() {
     console.log('Disconnecting');
-    if (this.transport) {
-      await this.transport.disconnect();
-      this.transport = null;
-    }
-    this.loader = null;
+    await this._cycleTransport();
+    this.serialPort = null;
     this.terminal.clean();
     console.log('Disconnected');
   }
@@ -140,37 +330,23 @@ export default class FlashManager {
     }
   }
 
-  private consoleRunning = false;
+  /**
+   * Sends an application command.
+   * Returns false and ignores if not in application mode or if disconnected.
+   */
+  async sendApplicationCommand(text: string) {
+    if (!this.serialPortWriter) return false;
+    if (this.loader) return false;
 
-  async readConsoleLoop() {
-    let ok = true;
-    this.consoleRunning = true;
-
+    text += "\n";
+    let buffer = new TextEncoder().encode(text);
     try {
-      await this._internalConsoleLoop();
+      await this.serialPortWriter.write(buffer);
+      return true;
     } catch (e) {
       console.error(e);
-      this.terminal.writeLine(`Failed to read console: ${e}`);
-      ok = false;
-    }
-
-    this.consoleRunning = false;
-
-    return ok;
-  }
-
-  private async _internalConsoleLoop() {
-    while (this.transport) {
-      const readLoop = this.transport.read(250);
-      while (true) {
-        const { value, done } = await readLoop.next();
-
-        if (!value || done) {
-          break;
-        }
-
-        this.terminal.write(value.toString());
-      }
+      this.terminal.writeLine(`Failed to write application command: ${e}`);
+      return false;
     }
   }
 }

--- a/src/routes/flashtool/+page.svelte
+++ b/src/routes/flashtool/+page.svelte
@@ -7,6 +7,7 @@
   import FlashManager from '$lib/EspTool/FlashManager';
   import SerialPortSelector from './SerialPortSelector.svelte';
   import { Button } from '$lib/components/ui/button';
+  import TextInput from '$lib/components/input/TextInput.svelte';
   import * as Card from '$lib/components/ui/card';
   import { Progress } from '$lib/components/ui/progress';
   import { FlashManagerStore } from '$lib/stores/FlashManagersStore';
@@ -30,6 +31,7 @@
 
   let terminalOpen = $state<boolean>(false);
   let terminalText = $state<string>('');
+  let terminalCommand = $state<string>('');
 
   const terminal = {
     clean: () => {
@@ -63,6 +65,43 @@
   let version = $state<string | null>(null);
   let board = $state<string | null>(null);
   let eraseBeforeFlash = $state<boolean>(false);
+
+  async function AppModeDevice() {
+    if (isFlashing) return;
+    try {
+      isFlashing = true;
+
+      if (!manager) {
+        terminal.writeLine(`Host-side error during reset: no device!`);
+        return;
+      }
+
+      await manager.ensureApplication(true);
+    } catch (e) {
+      terminal.writeLine(`Host-side error during reset: ${e}`);
+    } finally {
+      isFlashing = false;
+    }
+  }
+
+  async function RunCommand() {
+    if (isFlashing) return;
+    try {
+      isFlashing = true;
+
+      if (!manager) {
+        terminal.writeLine(`Couldn't send: no device!`);
+        return;
+      }
+
+      await manager.ensureApplication();
+      await manager.sendApplicationCommand(terminalCommand);
+    } catch (e) {
+      terminal.writeLine(`Couldn't send: ${e}`);
+    } finally {
+      isFlashing = false;
+    }
+  }
 </script>
 
 {#snippet mainContent()}
@@ -177,18 +216,29 @@
 </div>
 
 <Sheet bind:open={() => terminalOpen, (o) => (terminalOpen = o)}>
-  <SheetContent>
+  <SheetContent class="flex flex-col">
     <SheetHeader>
       <SheetTitle class="flex items-center">
         Console
         <div class="flex-1"></div>
         <Button class="m-2" onclick={() => (terminalText = '')}>Clear</Button>
+        <!-- Reset & start application -->
+        <Button onclick={AppModeDevice} disabled={!manager || isFlashing}>
+          Reset
+        </Button>
       </SheetTitle>
     </SheetHeader>
     <div
-      class="border-surface-500 flex h-max grow flex-col-reverse overflow-auto overflow-y-auto rounded-md border p-4"
+      class="border-surface-500 flex h-max grow shrink flex-col-reverse rounded-md border p-4"
+      style="overflow: scroll;"
     >
       <pre id="terminal" class="text-left text-xs">{terminalText}</pre>
     </div>
+    <TextInput
+      label="Command"
+      placeholder="Command"
+      button={{onClick: RunCommand}}
+      bind:value={terminalCommand}
+    />
   </SheetContent>
 </Sheet>

--- a/src/routes/flashtool/FirmwareFlasher.svelte
+++ b/src/routes/flashtool/FirmwareFlasher.svelte
@@ -42,6 +42,10 @@
       progressPercent = progress * 100;
     }
 
+    progressName = 'Resetting...';
+    progressPercent = undefined;
+    await manager.ensureBootloader();
+
     progressName = 'Downloading firmware...';
     progressPercent = undefined;
     const firmware = await DownloadFirmwareBinary(version, board, progressCallback);
@@ -75,12 +79,13 @@
 
     progressName = 'Rebooting device... (Reconnect to power manually if stuck)';
     progressPercent = undefined;
-    await manager.hardReset();
+    await manager.ensureApplication();
 
     progressName = 'Rebooted device! Flashing complete.';
     progressPercent = 100;
   }
   async function FlashDevice() {
+    if (isFlashing) return;
     try {
       isFlashing = true;
       await FlashDeviceImpl();


### PR DESCRIPTION
This implements a serial console into the flashtool.

It seems reasonably clear from the existing dummied-out code that this was considered, but not implemented, possibly due to esptool-js's Transport being buggy (it appears that if a read times out, Transport *will* lose data?)

The serial console UI probably needs work, but to enter in some administrative commands it works well *enough.*

![image](https://github.com/user-attachments/assets/921b33a6-469a-4aa9-a9cf-e2880d10ba26)

My personal motivation for this PR is that with some firmware extensions and further work, it should be possible to completely provision a hub entirely from the flashtool without using the captive portal. This leads to the potential for "captive-portal-less" hubs which will not leave a configuration interface open when the network is down.
