### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,6 +12,8 @@ name: ci-build
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -48,6 +50,9 @@ jobs:
   build-container:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/OpenShock/Frontend/security/code-scanning/5](https://github.com/OpenShock/Frontend/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow:
- The `test` job primarily installs dependencies, runs checks, and executes tests. It only requires `contents: read` permissions.
- The `build-container` job involves containerization and pushing images to a registry. It requires `contents: read` and `packages: write` permissions.

The `permissions` block can be added at the job level to ensure each job has the minimum required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
