### PR TITLE
Replace bowser with ua-parser-js for UA detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"@types/semver": "^7.7.1",
 		"@types/w3c-web-serial": "^1.0.8",
 		"bits-ui": "2.15.7",
-		"bowser": "^2.14.1",
 		"boxen": "^8.0.1",
 		"chalk": "^5.6.2",
 		"clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       bits-ui:
         specifier: 2.15.7
         version: 2.15.7(@internationalized/date@3.11.0)(@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)))(svelte@5.53.2)
-      bowser:
-        specifier: ^2.14.1
-        version: 2.14.1
       boxen:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1363,9 +1360,6 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
-
-  bowser@2.14.1:
-    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -3991,8 +3985,6 @@ snapshots:
       - '@sveltejs/kit'
 
   blake3-wasm@2.1.5: {}
-
-  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:

--- a/src/lib/utils/compatibility.ts
+++ b/src/lib/utils/compatibility.ts
@@ -21,7 +21,8 @@ export const isSerialSupported =
   'serial' in navigator &&
   navigator.serial !== undefined &&
   typeof navigator.serial.getPorts === 'function' &&
-  typeof navigator.serial.requestPort === 'function';
+  typeof navigator.serial.requestPort === 'function' &&
+  typeof navigator.serial.addEventListener === 'function';
 
 export function getBrowserName(): string {
   return parser?.getBrowser().name ?? '???';

--- a/src/lib/utils/compatibility.ts
+++ b/src/lib/utils/compatibility.ts
@@ -1,27 +1,28 @@
 import { browser } from '$app/environment';
+import { UAParser } from 'ua-parser-js';
 
-const fullMobileDetectionRegex =
-  /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i;
-const prefixMobileDetectionRegex =
-  /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i;
+const parser = browser ? new UAParser(navigator.userAgent) : null;
 
-function mobilecheck() {
+function mobileCheck(): boolean {
   if (!browser) return false;
 
+  // Fast path: Client Hints API (Chromium 85+)
   if (navigator.userAgentData?.mobile) return true;
 
-  const userAgentString = navigator.userAgent || navigator.vendor;
-  return (
-    fullMobileDetectionRegex.test(userAgentString) ||
-    prefixMobileDetectionRegex.test(userAgentString.slice(0, 4))
-  );
+  // Fallback: ua-parser-js regex parsing
+  const type = parser!.getDevice().type;
+  return type === 'mobile' || type === 'tablet';
 }
 
-export const isMobile = mobilecheck();
+export const isMobile = mobileCheck();
+
 export const isSerialSupported =
   browser &&
   'serial' in navigator &&
   navigator.serial !== undefined &&
   typeof navigator.serial.getPorts === 'function' &&
-  typeof navigator.serial.requestPort === 'function' &&
-  typeof navigator.serial.addEventListener === 'function';
+  typeof navigator.serial.requestPort === 'function';
+
+export function getBrowserName(): string {
+  return parser?.getBrowser().name ?? '???';
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,9 +22,7 @@
 
   let meta = $derived(buildMetaData(page.url));
 
-  let isOpen = $state(
-    !browser || isMobile ? false : localStorage.getItem('sidebarOpen') === 'true'
-  );
+  let isOpen = $state(browser && !isMobile && localStorage.getItem('sidebarOpen') === 'true');
   $effect(() => {
     if (!isMobile) localStorage.setItem('sidebarOpen', isOpen ? 'true' : 'false');
   });

--- a/src/routes/flashtool/+page.svelte
+++ b/src/routes/flashtool/+page.svelte
@@ -15,8 +15,7 @@
   import { Label } from '$lib/components/ui/label';
   import { Progress } from '$lib/components/ui/progress';
   import { Sheet, SheetContent, SheetHeader, SheetTitle } from '$lib/components/ui/sheet';
-  import { isSerialSupported } from '$lib/utils/compatibility';
-  import Bowser from 'bowser';
+  import { getBrowserName, isSerialSupported } from '$lib/utils/compatibility';
   import FirmwareBoardSelector from './FirmwareBoardSelector.svelte';
   import FirmwareFlasher from './FirmwareFlasher.svelte';
   import FlashManager from './FlashManager';
@@ -168,7 +167,7 @@
 
 {#snippet unsupportedBrowser()}
   <h3>Your browser does not support this feature.</h3>
-  {#if ['Chrome', 'Edge', 'Opera'].includes(Bowser.getParser(navigator.userAgent).getBrowserName())}
+  {#if ['Chrome', 'Edge', 'Opera'].includes(getBrowserName())}
     <h3 class="scroll-m-20 text-2xl font-semibold tracking-tight">
       Please update your browser to the latest version.
     </h3>


### PR DESCRIPTION
## TL;DR

Removes the `bowser` dependency and replaces all UA detection with `ua-parser-js` (already used elsewhere in the codebase).

## Changes

- Remove `bowser` dependency
- Rewrite mobile detection in `compatibility.ts` using `UAParser.getDevice().type` with `navigator.userAgentData.mobile` as a fast path for Chromium browsers
- Add `getBrowserName()` utility for Web Serial browser compatibility check in flashtool
- Simplify sidebar open state boolean in root layout

## Test plan

- [x] `pnpm run check` — 0 errors
- [x] `pnpm test:unit` — 128/128 tests pass
- [ ] Manual: verify mobile detection works on phone/tablet
- [ ] Manual: verify flashtool shows correct unsupported browser message

🤖 Generated with [Claude Code](https://claude.com/claude-code)