### PR TITLE
fix: improve LCP by SSR-ing welcome screen and preloading hero images

### DIFF
--- a/src/lib/tour/onboarding-state.ts
+++ b/src/lib/tour/onboarding-state.ts
@@ -35,7 +35,15 @@ export function hasSeenWelcome(): boolean {
 
 export function markWelcomed(): void {
   try {
-    document.cookie = `${WELCOME_COOKIE_NAME}=${CURRENT_WELCOME_VERSION}; path=/; expires=${WELCOME_COOKIE_EXPIRES.toUTCString()}; SameSite=Lax`;
+    cookieStore
+      .set({
+        name: WELCOME_COOKIE_NAME,
+        value: String(CURRENT_WELCOME_VERSION),
+        path: '/',
+        expires: WELCOME_COOKIE_EXPIRES.getTime(),
+        sameSite: 'lax',
+      })
+      .catch(() => {});
   } catch {
     // ignore
   }

--- a/src/lib/tour/onboarding-state.ts
+++ b/src/lib/tour/onboarding-state.ts
@@ -1,9 +1,18 @@
 import { PUBLIC_DISABLE_ONBOARDING } from '$env/static/public';
 import { isTruthy } from '$lib/utils/parse';
 
-const CURRENT_WELCOME_VERSION = 1;
-export const WELCOME_COOKIE_NAME = 'os.welcomeVersion';
+export const WELCOME_COOKIE_NAME = 'os.welcomed';
+// Pre-cookie builds stored "welcome seen" under this localStorage key. Kept only
+// for the migration fallback in hasSeenWelcome().
+const LEGACY_WELCOME_STORAGE_KEY = 'os.welcomeVersion';
 const WELCOME_COOKIE_EXPIRES = new Date('2026-07-10');
+// Retire the welcome screen one day before the cookie expires, so it can't briefly
+// reappear for everyone in the window where the cookie lapses.
+const WELCOME_SUNSET = new Date(WELCOME_COOKIE_EXPIRES.getTime() - 24 * 60 * 60 * 1000);
+
+export function isWelcomeSunset(): boolean {
+  return Date.now() >= WELCOME_SUNSET.getTime();
+}
 
 const CURRENT_TOUR_VERSION = 1;
 const TOUR_VERSION_KEY = 'os.tourCompletedVersion';
@@ -12,22 +21,22 @@ export function isOnboardingDisabled(): boolean {
   return isTruthy(PUBLIC_DISABLE_ONBOARDING);
 }
 
-function readWelcomeCookie(): number {
+function readWelcomeCookie(): boolean {
   try {
-    const match = document.cookie.match(/(?:^|;\s*)os\.welcomeVersion=([^;]*)/);
-    return match ? parseInt(match[1], 10) : 0;
+    const escapedName = WELCOME_COOKIE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`));
+    return match ? isTruthy(decodeURIComponent(match[1])) : false;
   } catch {
-    return 0;
+    return false;
   }
 }
 
 export function hasSeenWelcome(): boolean {
-  // Check cookie (new path) then fall back to localStorage (migration).
-  if (readWelcomeCookie() >= CURRENT_WELCOME_VERSION) return true;
+  // Check cookie (new path) then fall back to localStorage (migration). isTruthy
+  // also accepts the legacy version value "1", so pre-existing state still counts.
+  if (readWelcomeCookie()) return true;
   try {
-    const raw = localStorage.getItem(WELCOME_COOKIE_NAME);
-    const seen = raw ? parseInt(raw, 10) : 0;
-    return Number.isFinite(seen) && seen >= CURRENT_WELCOME_VERSION;
+    return isTruthy(localStorage.getItem(LEGACY_WELCOME_STORAGE_KEY));
   } catch {
     return false;
   }
@@ -38,7 +47,7 @@ export function markWelcomed(): void {
     cookieStore
       .set({
         name: WELCOME_COOKIE_NAME,
-        value: String(CURRENT_WELCOME_VERSION),
+        value: 'true',
         path: '/',
         expires: WELCOME_COOKIE_EXPIRES.getTime(),
         sameSite: 'lax',
@@ -50,7 +59,7 @@ export function markWelcomed(): void {
 }
 
 export function shouldShowWelcome(): boolean {
-  if (isOnboardingDisabled()) return false;
+  if (isOnboardingDisabled() || isWelcomeSunset()) return false;
   return !hasSeenWelcome();
 }
 

--- a/src/lib/tour/onboarding-state.ts
+++ b/src/lib/tour/onboarding-state.ts
@@ -44,15 +44,10 @@ export function hasSeenWelcome(): boolean {
 
 export function markWelcomed(): void {
   try {
-    cookieStore
-      .set({
-        name: WELCOME_COOKIE_NAME,
-        value: 'true',
-        path: '/',
-        expires: WELCOME_COOKIE_EXPIRES.getTime(),
-        sameSite: 'lax',
-      })
-      .catch(() => {});
+    // Synchronous document.cookie write. The async cookieStore API would also work
+    // (Chrome 87+, Firefox 140+, Safari 18.4+), but for a one-shot write it buys
+    // nothing and drops older browsers, so the plain string write is preferred.
+    document.cookie = `${WELCOME_COOKIE_NAME}=true; path=/; expires=${WELCOME_COOKIE_EXPIRES.toUTCString()}; SameSite=Lax`;
   } catch {
     // ignore
   }

--- a/src/lib/tour/onboarding-state.ts
+++ b/src/lib/tour/onboarding-state.ts
@@ -2,7 +2,8 @@ import { PUBLIC_DISABLE_ONBOARDING } from '$env/static/public';
 import { isTruthy } from '$lib/utils/parse';
 
 const CURRENT_WELCOME_VERSION = 1;
-const WELCOME_VERSION_KEY = 'os.welcomeVersion';
+export const WELCOME_COOKIE_NAME = 'os.welcomeVersion';
+const WELCOME_COOKIE_EXPIRES = new Date('2026-07-10');
 
 const CURRENT_TOUR_VERSION = 1;
 const TOUR_VERSION_KEY = 'os.tourCompletedVersion';
@@ -11,9 +12,20 @@ export function isOnboardingDisabled(): boolean {
   return isTruthy(PUBLIC_DISABLE_ONBOARDING);
 }
 
-export function hasSeenWelcome(): boolean {
+function readWelcomeCookie(): number {
   try {
-    const raw = localStorage.getItem(WELCOME_VERSION_KEY);
+    const match = document.cookie.match(/(?:^|;\s*)os\.welcomeVersion=([^;]*)/);
+    return match ? parseInt(match[1], 10) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function hasSeenWelcome(): boolean {
+  // Check cookie (new path) then fall back to localStorage (migration).
+  if (readWelcomeCookie() >= CURRENT_WELCOME_VERSION) return true;
+  try {
+    const raw = localStorage.getItem(WELCOME_COOKIE_NAME);
     const seen = raw ? parseInt(raw, 10) : 0;
     return Number.isFinite(seen) && seen >= CURRENT_WELCOME_VERSION;
   } catch {
@@ -23,21 +35,15 @@ export function hasSeenWelcome(): boolean {
 
 export function markWelcomed(): void {
   try {
-    localStorage.setItem(WELCOME_VERSION_KEY, String(CURRENT_WELCOME_VERSION));
+    document.cookie = `${WELCOME_COOKIE_NAME}=${CURRENT_WELCOME_VERSION}; path=/; expires=${WELCOME_COOKIE_EXPIRES.toUTCString()}; SameSite=Lax`;
   } catch {
-    // ignore (private mode, quota, etc.)
+    // ignore
   }
 }
 
 export function shouldShowWelcome(): boolean {
   if (isOnboardingDisabled()) return false;
-  try {
-    const raw = localStorage.getItem(WELCOME_VERSION_KEY);
-    const seen = raw ? parseInt(raw, 10) : 0;
-    return !Number.isFinite(seen) || seen < CURRENT_WELCOME_VERSION;
-  } catch {
-    return false;
-  }
+  return !hasSeenWelcome();
 }
 
 export function hasCompletedTour(): boolean {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,8 +1,7 @@
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants';
-import { WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
+import { isWelcomeSunset, WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
+import { isTruthy } from '$lib/utils/parse';
 import type { LayoutServerLoad } from './$types';
-
-const CURRENT_WELCOME_VERSION = 1;
 
 export const load: LayoutServerLoad = ({ cookies }) => {
   // The sidebar provider writes this cookie on every toggle, but nothing reads
@@ -10,10 +9,19 @@ export const load: LayoutServerLoad = ({ cookies }) => {
   // state and we avoid a collapse-then-expand flash on hydration.
   const sidebarOpen = cookies.get(SIDEBAR_COOKIE_NAME) === 'true';
 
-  // Determine server-side whether to SSR the welcome screen, so the logo is
-  // in the initial HTML for new visitors rather than loaded after JS runs.
-  const welcomeRaw = cookies.get(WELCOME_COOKIE_NAME);
-  const showWelcome = !welcomeRaw || parseInt(welcomeRaw, 10) < CURRENT_WELCOME_VERSION;
+  // Past the sunset date the welcome screen is retired — never SSR it, and clear
+  // the cookie if a returning visitor still has it set.
+  if (isWelcomeSunset()) {
+    if (cookies.get(WELCOME_COOKIE_NAME) !== undefined) {
+      cookies.delete(WELCOME_COOKIE_NAME, { path: '/' });
+    }
+    return { sidebarOpen, showWelcome: false };
+  }
+
+  // SSR the welcome screen for visitors who haven't seen it, so the logo is in
+  // the initial HTML rather than loaded after JS runs. Any non-truthy/missing
+  // cookie (including malformed) counts as "not seen".
+  const showWelcome = !isTruthy(cookies.get(WELCOME_COOKIE_NAME));
 
   return { sidebarOpen, showWelcome };
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,9 @@
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants';
-import { isOnboardingDisabled, isWelcomeSunset, WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
+import {
+  isOnboardingDisabled,
+  isWelcomeSunset,
+  WELCOME_COOKIE_NAME,
+} from '$lib/tour/onboarding-state';
 import { isTruthy } from '$lib/utils/parse';
 import type { LayoutServerLoad } from './$types';
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,5 @@
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants';
-import { isWelcomeSunset, WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
+import { isOnboardingDisabled, isWelcomeSunset, WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
 import { isTruthy } from '$lib/utils/parse';
 import type { LayoutServerLoad } from './$types';
 
@@ -8,6 +8,12 @@ export const load: LayoutServerLoad = ({ cookies }) => {
   // it back. Read it here so the server renders the persisted open/collapsed
   // state and we avoid a collapse-then-expand flash on hydration.
   const sidebarOpen = cookies.get(SIDEBAR_COOKIE_NAME) === 'true';
+
+  // When onboarding is disabled the client unmounts the screen immediately on
+  // hydration, so SSR-ing it just hurts LCP — skip it server-side too.
+  if (isOnboardingDisabled()) {
+    return { sidebarOpen, showWelcome: false };
+  }
 
   // Past the sunset date the welcome screen is retired — never SSR it, and clear
   // the cookie if a returning visitor still has it set.

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,9 +1,19 @@
 import { SIDEBAR_COOKIE_NAME } from '$lib/components/ui/sidebar/constants';
+import { WELCOME_COOKIE_NAME } from '$lib/tour/onboarding-state';
 import type { LayoutServerLoad } from './$types';
+
+const CURRENT_WELCOME_VERSION = 1;
 
 export const load: LayoutServerLoad = ({ cookies }) => {
   // The sidebar provider writes this cookie on every toggle, but nothing reads
   // it back. Read it here so the server renders the persisted open/collapsed
   // state and we avoid a collapse-then-expand flash on hydration.
-  return { sidebarOpen: cookies.get(SIDEBAR_COOKIE_NAME) === 'true' };
+  const sidebarOpen = cookies.get(SIDEBAR_COOKIE_NAME) === 'true';
+
+  // Determine server-side whether to SSR the welcome screen, so the logo is
+  // in the initial HTML for new visitors rather than loaded after JS runs.
+  const welcomeRaw = cookies.get(WELCOME_COOKIE_NAME);
+  const showWelcome = !welcomeRaw || parseInt(welcomeRaw, 10) < CURRENT_WELCOME_VERSION;
+
+  return { sidebarOpen, showWelcome };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,6 +32,8 @@
   let sidebarOpen = $state(untrack(() => data.sidebarOpen));
   const isOpen = $derived(mobile.current ? false : sidebarOpen);
 
+  let welcomeOpen = $state(untrack(() => data.showWelcome));
+
   onMount(() => maybePromptTelemetryConsent());
 </script>
 
@@ -44,7 +46,13 @@
 <TooltipProvider delayDuration={250}>
   <DialogManager />
 
-  <WelcomeScreen />
+  {#if welcomeOpen}
+    <WelcomeScreen
+      close={() => {
+        welcomeOpen = false;
+      }}
+    />
+  {/if}
 
   <SidebarProvider open={isOpen} onOpenChange={(v) => (sidebarOpen = v)}>
     <Sidebar />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,11 @@
   let grid: DotGrid | undefined = $state();
 </script>
 
+<svelte:head>
+  <link rel="preload" href={asset('/IconSpinning.svg')} as="image" type="image/svg+xml" />
+  <link rel="preload" href={asset('/LogoBakedFont.svg')} as="image" type="image/svg+xml" />
+</svelte:head>
+
 <section
   aria-label="Home"
   class="relative flex h-full flex-col items-center justify-center space-y-6 overflow-hidden text-center text-white"
@@ -18,8 +23,18 @@
   <DotGrid bind:this={grid} />
 
   <span class="relative flex">
-    <img class="h-9 pr-2 sm:h-14 md:h-20 md:pr-4" src={asset('/IconSpinning.svg')} alt="logo" />
-    <img class="h-9 sm:h-14 md:h-20" src={asset('/LogoBakedFont.svg')} alt="logo" />
+    <img
+      class="h-9 pr-2 sm:h-14 md:h-20 md:pr-4"
+      src={asset('/IconSpinning.svg')}
+      alt="logo"
+      fetchpriority="high"
+    />
+    <img
+      class="h-9 sm:h-14 md:h-20"
+      src={asset('/LogoBakedFont.svg')}
+      alt="logo"
+      fetchpriority="high"
+    />
   </span>
   <p class="relative text-lg opacity-75 md:text-2xl">
     The go-to platform for safe, reliable, real low-latency remote shocking.<br />

--- a/src/routes/WelcomeScreen.svelte
+++ b/src/routes/WelcomeScreen.svelte
@@ -27,28 +27,34 @@
     body: Snippet;
   }
 
+  interface Props {
+    close: () => void;
+  }
+
+  let { close }: Props = $props();
+
   const steps: Step[] = [
     { title: 'Welcome to the new OpenShock', body: stepWelcome },
     { title: "What's new", body: stepFeatures },
     { title: 'Bookmarks still work', body: stepRedirects },
     { title: 'Found a bug?', body: stepFeedback },
   ];
-
-  let open = $state(false);
   let step = $state(0);
   let reducedMotion = $state(false);
   let stepDirection = $state(1);
 
   onMount(() => {
-    if (!shouldShowWelcome()) return;
+    // Migration: no cookie yet but localStorage says already seen — backfill cookie and hide.
+    if (!shouldShowWelcome()) {
+      markWelcomed();
+      close();
+      return;
+    }
 
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     reducedMotion = mq.matches;
     const onChange = (e: MediaQueryListEvent) => (reducedMotion = e.matches);
     mq.addEventListener('change', onChange);
-
-    open = true;
-
     return () => mq.removeEventListener('change', onChange);
   });
 
@@ -71,17 +77,17 @@
   function dismiss() {
     markWelcomed();
     markTourCompleted();
-    open = false;
+    close();
   }
 
   function finish() {
     markWelcomed();
-    open = false;
+    close();
   }
 
   async function dismissAndStartTour() {
     markWelcomed();
-    open = false;
+    close();
     // Give the dialog a frame to unmount so the tour can highlight the
     // real sidebar underneath, not the now-fading welcome screen.
     await new Promise((r) => requestAnimationFrame(r));
@@ -92,7 +98,6 @@
   let canStartTour = $derived(userState.self !== null);
 
   function handleKeydown(e: KeyboardEvent) {
-    if (!open) return;
     if (e.key === 'Escape') dismiss();
     else if (e.key === 'ArrowRight') goNext();
     else if (e.key === 'Enter') {
@@ -106,131 +111,128 @@
 
   let grid: DotGrid | undefined = $state();
   let dialogEl: HTMLDivElement | undefined = $state();
-  let focusOrigin: HTMLElement | null = null;
 
-  $effect(() => {
-    if (open) {
-      focusOrigin = document.activeElement as HTMLElement | null;
-      queueMicrotask(() => dialogEl?.focus());
-      window.addEventListener('keydown', handleKeydown);
-      return () => {
-        window.removeEventListener('keydown', handleKeydown);
-      };
-    } else if (focusOrigin) {
-      focusOrigin.focus();
-      focusOrigin = null;
-    }
+  onMount(() => {
+    const focusOrigin = document.activeElement as HTMLElement | null;
+    queueMicrotask(() => dialogEl?.focus());
+    window.addEventListener('keydown', handleKeydown);
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+      focusOrigin?.focus();
+    };
   });
 </script>
 
-{#if open}
-  <div
-    bind:this={dialogEl}
-    class="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-[#08080c] select-none"
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="welcome-title"
-    tabindex="-1"
-    onpointermove={(e) => !reducedMotion && grid?.handlePointerMove(e)}
-  >
-    <!-- Background: base dot grid + brighter spotlight grid masked around the cursor -->
-    <DotGrid bind:this={grid} />
+<svelte:head>
+  <link rel="preload" href={asset('/logo.svg')} as="image" type="image/svg+xml" />
+</svelte:head>
 
-    <!-- Stories-style segmented progress along the top edge. Pure indicator, no auto-advance. -->
-    <div class="absolute top-4 right-6 left-6 flex gap-1.5" aria-label="Progress">
-      {#each steps as _, i (i)}
-        <button
-          type="button"
-          aria-label="Go to step {i + 1}"
-          onclick={() => goTo(i)}
-          class="h-1 flex-1 cursor-pointer overflow-hidden rounded-full bg-white/15 transition hover:bg-white/25"
+<div
+  bind:this={dialogEl}
+  class="fixed inset-0 z-50 flex items-center justify-center overflow-hidden bg-[#08080c] select-none"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="welcome-title"
+  tabindex="-1"
+  onpointermove={(e) => !reducedMotion && grid?.handlePointerMove(e)}
+>
+  <!-- Background: base dot grid + brighter spotlight grid masked around the cursor -->
+  <DotGrid bind:this={grid} />
+
+  <!-- Stories-style segmented progress along the top edge. Pure indicator, no auto-advance. -->
+  <div class="absolute top-4 right-6 left-6 flex gap-1.5" aria-label="Progress">
+    {#each steps as _, i (i)}
+      <button
+        type="button"
+        aria-label="Go to step {i + 1}"
+        onclick={() => goTo(i)}
+        class="h-1 flex-1 cursor-pointer overflow-hidden rounded-full bg-white/15 transition hover:bg-white/25"
+      >
+        <span
+          class="block h-full origin-left rounded-full bg-white/90 transition-transform duration-500"
+          style:transform={i <= step ? 'scaleX(1)' : 'scaleX(0)'}
+        ></span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="relative flex h-full w-full max-w-4xl flex-col px-6 py-16 sm:px-10">
+    <div class="flex flex-1 flex-col justify-center overflow-hidden">
+      {#key step}
+        <div
+          class="flex flex-col"
+          in:fly={{
+            x: reducedMotion ? 0 : 40 * stepDirection,
+            duration: reducedMotion ? 0 : 350,
+            easing: cubicOut,
+            opacity: 0,
+          }}
         >
-          <span
-            class="block h-full origin-left rounded-full bg-white/90 transition-transform duration-500"
-            style:transform={i <= step ? 'scaleX(1)' : 'scaleX(0)'}
-          ></span>
-        </button>
-      {/each}
+          {#if isFirst}
+            <h1 id="welcome-title" class="sr-only">Welcome to OpenShock</h1>
+          {:else}
+            <p class="mb-2 text-xs tracking-widest text-white/50 uppercase">
+              Step {step + 1} of {steps.length}
+            </p>
+            <h1 id="welcome-title" class="mb-6 text-3xl font-bold text-white sm:text-4xl">
+              {steps[step].title}
+            </h1>
+          {/if}
+          <div class="text-base leading-relaxed text-white/80">
+            {@render steps[step].body()}
+          </div>
+        </div>
+      {/key}
     </div>
 
-    <div class="relative flex h-full w-full max-w-4xl flex-col px-6 py-16 sm:px-10">
-      <div class="flex flex-1 flex-col justify-center overflow-hidden">
-        {#key step}
-          <div
-            class="flex flex-col"
-            in:fly={{
-              x: reducedMotion ? 0 : 40 * stepDirection,
-              duration: reducedMotion ? 0 : 350,
-              easing: cubicOut,
-              opacity: 0,
-            }}
-          >
-            {#if isFirst}
-              <h1 id="welcome-title" class="sr-only">Welcome to OpenShock</h1>
-            {:else}
-              <p class="mb-2 text-xs tracking-widest text-white/50 uppercase">
-                Step {step + 1} of {steps.length}
-              </p>
-              <h1 id="welcome-title" class="mb-6 text-3xl font-bold text-white sm:text-4xl">
-                {steps[step].title}
-              </h1>
-            {/if}
-            <div class="text-base leading-relaxed text-white/80">
-              {@render steps[step].body()}
-            </div>
-          </div>
-        {/key}
-      </div>
-
-      <div class="mt-10 flex flex-none flex-col gap-6">
-        <div class="flex items-center justify-between gap-2">
+    <div class="mt-10 flex flex-none flex-col gap-6">
+      <div class="flex items-center justify-between gap-2">
+        <Button
+          variant="ghost"
+          size="lg"
+          class="text-white/70 hover:bg-white/10 hover:text-white"
+          onclick={dismiss}
+        >
+          Skip
+        </Button>
+        <div class="flex gap-3">
           <Button
-            variant="ghost"
+            variant="outline"
             size="lg"
-            class="text-white/70 hover:bg-white/10 hover:text-white"
-            onclick={dismiss}
+            class="w-32 border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white {isFirst
+              ? 'pointer-events-none opacity-0'
+              : ''}"
+            aria-hidden={isFirst}
+            tabindex={isFirst ? -1 : 0}
+            onclick={goPrev}
           >
-            Skip
+            <ChevronLeft />
+            Back
           </Button>
-          <div class="flex gap-3">
+          {#if isLast && canStartTour}
             <Button
-              variant="outline"
               size="lg"
-              class="w-32 border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white {isFirst
-                ? 'pointer-events-none opacity-0'
-                : ''}"
-              aria-hidden={isFirst}
-              tabindex={isFirst ? -1 : 0}
-              onclick={goPrev}
+              class="w-44 bg-white text-black shadow-lg shadow-white/10 hover:bg-white/90"
+              onclick={dismissAndStartTour}
             >
-              <ChevronLeft />
-              Back
+              <Sparkles />
+              Show me around
             </Button>
-            {#if isLast && canStartTour}
-              <Button
-                size="lg"
-                class="w-44 bg-white text-black shadow-lg shadow-white/10 hover:bg-white/90"
-                onclick={dismissAndStartTour}
-              >
-                <Sparkles />
-                Show me around
-              </Button>
-            {:else}
-              <Button
-                size="lg"
-                class="w-44 bg-white text-black shadow-lg shadow-white/10 hover:bg-white/90"
-                onclick={goNext}
-              >
-                {isLast ? 'Get started' : 'Next'}
-                {#if !isLast}<ChevronRight />{/if}
-              </Button>
-            {/if}
-          </div>
+          {:else}
+            <Button
+              size="lg"
+              class="w-44 bg-white text-black shadow-lg shadow-white/10 hover:bg-white/90"
+              onclick={goNext}
+            >
+              {isLast ? 'Get started' : 'Next'}
+              {#if !isLast}<ChevronRight />{/if}
+            </Button>
+          {/if}
         </div>
       </div>
     </div>
   </div>
-{/if}
+</div>
 
 {#snippet stepWelcome()}
   <div class="flex flex-col items-center text-center">
@@ -247,6 +249,7 @@
       src={asset('/logo.svg')}
       alt="OpenShock"
       draggable="false"
+      fetchpriority="high"
       in:fade={{ duration: 700, delay: 200 }}
     />
 

--- a/src/routes/WelcomeScreen.svelte
+++ b/src/routes/WelcomeScreen.svelte
@@ -45,6 +45,7 @@
 
   onMount(() => {
     // Migration: no cookie yet but localStorage says already seen — backfill cookie and hide.
+    // Bail before wiring up focus/keydown so returning users don't get a brief focus jump.
     if (!shouldShowWelcome()) {
       markWelcomed();
       close();
@@ -55,7 +56,16 @@
     reducedMotion = mq.matches;
     const onChange = (e: MediaQueryListEvent) => (reducedMotion = e.matches);
     mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
+
+    const focusOrigin = document.activeElement as HTMLElement | null;
+    queueMicrotask(() => dialogEl?.focus());
+    window.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      mq.removeEventListener('change', onChange);
+      window.removeEventListener('keydown', handleKeydown);
+      focusOrigin?.focus();
+    };
   });
 
   function goTo(i: number) {
@@ -111,16 +121,6 @@
 
   let grid: DotGrid | undefined = $state();
   let dialogEl: HTMLDivElement | undefined = $state();
-
-  onMount(() => {
-    const focusOrigin = document.activeElement as HTMLElement | null;
-    queueMicrotask(() => dialogEl?.focus());
-    window.addEventListener('keydown', handleKeydown);
-    return () => {
-      window.removeEventListener('keydown', handleKeydown);
-      focusOrigin?.focus();
-    };
-  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
- SSR the welcome screen for new visitors using a cookie read in `+layout.server.ts`
- Unmount it via a `close` callback once dismissed
- Add `<link rel="preload">` and `fetchpriority="high"` to hero SVGs on the home page and welcome screen
- Migrate welcome state from localStorage to cookies so the server can skip rendering it on return visits
- Fix `hasSeenWelcome()` to check cookies so the deferred tour prompt still works for new users