### PR TITLE
chore(security): use isTruthy for telemetry env flags and add rel=noopener

### DIFF
--- a/src/lib/components/Turnstile.svelte
+++ b/src/lib/components/Turnstile.svelte
@@ -92,7 +92,7 @@
         class="mb-auto ml-auto h-7 w-auto text-[#666] dark:text-[#999]"
         href="https://www.cloudflare.com/products/turnstile/?utm_source=turnstile&utm_campaign=widget"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         <CloudflareLogo class="mb-px h-[26px]" />
       </a>

--- a/src/lib/components/Turnstile.svelte
+++ b/src/lib/components/Turnstile.svelte
@@ -92,7 +92,7 @@
         class="mb-auto ml-auto h-7 w-auto text-[#666] dark:text-[#999]"
         href="https://www.cloudflare.com/products/turnstile/?utm_source=turnstile&utm_campaign=widget"
         target="_blank"
-        rel="noreferrer"
+        rel="noopener"
       >
         <CloudflareLogo class="mb-px h-[26px]" />
       </a>

--- a/src/lib/telemetry/common.ts
+++ b/src/lib/telemetry/common.ts
@@ -8,6 +8,7 @@ import {
   PUBLIC_SIGNOZ_TRACES_URL,
 } from '$env/static/public';
 import { telemetryConsent, type TelemetryLevel } from '$lib/state/telemetry-consent-state.svelte';
+import { isTruthy } from '$lib/utils/parse';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 
 export const SERVICE_NAME = 'openshock-frontend';
@@ -79,7 +80,7 @@ export function telemetryLevel(): TelemetryLevel {
   if (typeof window === 'undefined') return 'off';
 
   // Deployment kill-switch: only ship from a deployment with a configured collector.
-  if (PUBLIC_SIGNOZ_LOGS_ENABLED !== 'true') return 'off';
+  if (!isTruthy(PUBLIC_SIGNOZ_LOGS_ENABLED)) return 'off';
 
   // Opt-in: respect the user's chosen consent level.
   return telemetryConsent.value;

--- a/src/lib/telemetry/tracer.ts
+++ b/src/lib/telemetry/tracer.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_SIGNOZ_TRACE_PROPAGATION } from '$env/static/public';
+import { isTruthy } from '$lib/utils/parse';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
@@ -38,7 +39,7 @@ export function initTracing(): void {
   // Distributed tracing: attach `traceparent`/`tracestate` to API requests so the backend can
   // continue the trace. Cross-origin, so the backend's CORS must allow those request headers —
   // off by default to avoid breaking API calls before the backend is ready.
-  const propagateToBackend = PUBLIC_SIGNOZ_TRACE_PROPAGATION === 'true';
+  const propagateToBackend = isTruthy(PUBLIC_SIGNOZ_TRACE_PROPAGATION);
 
   registerInstrumentations({
     instrumentations: [

--- a/src/routes/(auth)/login/+page.svelte
+++ b/src/routes/(auth)/login/+page.svelte
@@ -150,8 +150,13 @@
   </Card.Content>
 </Card.Root>
 <FieldDescription class="px-6 text-center">
-  By clicking Login, you agree to our <a href="https://openshock.org/tos" target="_blank"
-    >Terms of Service</a
+  By clicking Login, you agree to our <a
+    href="https://openshock.org/tos"
+    target="_blank"
+    rel="noopener noreferrer">Terms of Service</a
   >
-  and <a href="https://openshock.org/privacy" target="_blank">Privacy Policy</a>.
+  and
+  <a href="https://openshock.org/privacy" target="_blank" rel="noopener noreferrer"
+    >Privacy Policy</a
+  >.
 </FieldDescription>

--- a/src/routes/(auth)/login/+page.svelte
+++ b/src/routes/(auth)/login/+page.svelte
@@ -150,13 +150,8 @@
   </Card.Content>
 </Card.Root>
 <FieldDescription class="px-6 text-center">
-  By clicking Login, you agree to our <a
-    href="https://openshock.org/tos"
-    target="_blank"
-    rel="noopener">Terms of Service</a
-  >
+  By clicking Login, you agree to our
+  <a href="https://openshock.org/tos" target="_blank" rel="noopener">Terms of Service</a>
   and
-  <a href="https://openshock.org/privacy" target="_blank" rel="noopener"
-    >Privacy Policy</a
-  >.
+  <a href="https://openshock.org/privacy" target="_blank" rel="noopener">Privacy Policy</a>.
 </FieldDescription>

--- a/src/routes/(auth)/login/+page.svelte
+++ b/src/routes/(auth)/login/+page.svelte
@@ -153,10 +153,10 @@
   By clicking Login, you agree to our <a
     href="https://openshock.org/tos"
     target="_blank"
-    rel="noopener noreferrer">Terms of Service</a
+    rel="noopener">Terms of Service</a
   >
   and
-  <a href="https://openshock.org/privacy" target="_blank" rel="noopener noreferrer"
+  <a href="https://openshock.org/privacy" target="_blank" rel="noopener"
     >Privacy Policy</a
   >.
 </FieldDescription>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -17,7 +17,7 @@
     Made with
     <span style="color: #e25555;">&#9829;</span>
     by the
-    <a target="_blank" rel="noopener" href={PUBLIC_GITHUB_PROJECT_URL}> OpenShock Team</a>
+    <a target="_blank" rel="noopener" href={PUBLIC_GITHUB_PROJECT_URL}>OpenShock Team</a>
   </div>
   <div class="flex items-center gap-2">
     <DropdownMenu.Root>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -17,9 +17,7 @@
     Made with
     <span style="color: #e25555;">&#9829;</span>
     by the
-    <a target="_blank" rel="noopener noreferrer" href={PUBLIC_GITHUB_PROJECT_URL}>
-      OpenShock Team</a
-    >
+    <a target="_blank" rel="noopener" href={PUBLIC_GITHUB_PROJECT_URL}> OpenShock Team</a>
   </div>
   <div class="flex items-center gap-2">
     <DropdownMenu.Root>

--- a/src/routes/WelcomeScreen.svelte
+++ b/src/routes/WelcomeScreen.svelte
@@ -326,7 +326,7 @@
     <a
       href={PUBLIC_GITHUB_PROJECT_URL}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       class="group flex items-center gap-4 rounded-xl border border-white/10 bg-[#13131a] p-4 transition hover:border-white/30 hover:bg-[#181821]"
     >
       <div

--- a/src/routes/terminal/HelpDialog.svelte
+++ b/src/routes/terminal/HelpDialog.svelte
@@ -129,12 +129,7 @@
       <li>what you've already tried from the previous steps</li>
       <li>any error messages or relevant terminal output</li>
     </ul>
-    <Button
-      href={PUBLIC_DISCORD_INVITE_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="w-fit"
-    >
+    <Button href={PUBLIC_DISCORD_INVITE_URL} target="_blank" rel="noopener" class="w-fit">
       <DiscordLogo class="fill-white dark:fill-black" />
       Join our Discord server
     </Button>

--- a/src/routes/terminal/HelpDialog.svelte
+++ b/src/routes/terminal/HelpDialog.svelte
@@ -74,6 +74,7 @@
       <Button
         href="https://download.openshock.org/drivers/CP210x_Universal_Windows_Driver.zip"
         target="_blank"
+        rel="noopener noreferrer"
       >
         <ArrowDownToLine />
         CP210x Universal Windows Driver
@@ -128,7 +129,12 @@
       <li>what you've already tried from the previous steps</li>
       <li>any error messages or relevant terminal output</li>
     </ul>
-    <Button href={PUBLIC_DISCORD_INVITE_URL} target="_blank" class="w-fit">
+    <Button
+      href={PUBLIC_DISCORD_INVITE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="w-fit"
+    >
       <DiscordLogo class="fill-white dark:fill-black" />
       Join our Discord server
     </Button>

--- a/src/routes/terminal/HelpDialog.svelte
+++ b/src/routes/terminal/HelpDialog.svelte
@@ -74,7 +74,7 @@
       <Button
         href="https://download.openshock.org/drivers/CP210x_Universal_Windows_Driver.zip"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noopener"
       >
         <ArrowDownToLine />
         CP210x Universal Windows Driver


### PR DESCRIPTION
- Telemetry kill-switch (PUBLIC_SIGNOZ_LOGS_ENABLED) and trace propagation flag now use isTruthy() instead of strict === 'true' comparison, matching the project convention for env-var booleans.
- Add rel=noopener noreferrer to external target=_blank links on the login page and serial terminal help dialog.