### PR TITLE
fix(a11y): add accessible names to icon-only controls

### DIFF
--- a/src/routes/(app)/shares/user/incoming/manage-share.svelte
+++ b/src/routes/(app)/shares/user/incoming/manage-share.svelte
@@ -89,7 +89,13 @@
                     >
                       <Copy />
                     </Button>
-                    <Button variant="destructive" onclick={() => handleDeleteClick(shocker)}>
+                    <Button
+                      variant="destructive"
+                      size="icon"
+                      title="Remove share"
+                      aria-label="Remove share"
+                      onclick={() => handleDeleteClick(shocker)}
+                    >
                       <Trash />
                     </Button>
                   </div>

--- a/src/routes/(app)/shares/user/invites/incoming-invite-item.svelte
+++ b/src/routes/(app)/shares/user/invites/incoming-invite-item.svelte
@@ -92,6 +92,7 @@
       <Tooltip.Trigger
         class={cn('mr-4 size-9', buttonVariants({ variant: 'default' }))}
         onclick={acceptInvite}
+        aria-label="Accept invite"
       >
         <Check />
       </Tooltip.Trigger>
@@ -104,6 +105,7 @@
       <Tooltip.Trigger
         class={cn('mr-4 size-9', buttonVariants({ variant: 'destructive' }))}
         onclick={denyInvite}
+        aria-label="Deny invite"
       >
         <X />
       </Tooltip.Trigger>

--- a/src/routes/(app)/shares/user/invites/outgoing-invite-item.svelte
+++ b/src/routes/(app)/shares/user/invites/outgoing-invite-item.svelte
@@ -106,6 +106,7 @@
       <Tooltip.Trigger
         class={cn('mr-4 size-9', buttonVariants({ variant: 'destructive' }))}
         onclick={removeInvite}
+        aria-label="Cancel invite"
       >
         <X />
       </Tooltip.Trigger>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -25,7 +25,13 @@
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         {#snippet child({ props })}
-          <Button {...props} variant="ghost" size="icon" class="h-4 w-4">
+          <Button
+            {...props}
+            variant="ghost"
+            size="icon"
+            class="h-4 w-4"
+            aria-label="Server connection status"
+          >
             {#if getConnectionState() === HubConnectionState.Connected}
               <Wifi class="h-4 w-4 text-green-800" />
             {:else}

--- a/src/routes/terminal/SerialTerminal.svelte
+++ b/src/routes/terminal/SerialTerminal.svelte
@@ -308,7 +308,14 @@
         placeholder="Type a command..."
         {disabled}
       />
-      <Button size="sm" variant="ghost" onclick={sendCommand} {disabled}>
+      <Button
+        size="sm"
+        variant="ghost"
+        onclick={sendCommand}
+        {disabled}
+        title="Send command"
+        aria-label="Send command"
+      >
         <Send class="h-3.5 w-3.5" />
       </Button>
     </div>


### PR DESCRIPTION
Add aria-label (and title where helpful) to icon-only buttons that had no accessible name: the remove-share button, footer connection-status indicator, serial-terminal send button, and the invite accept/deny/cancel tooltip triggers (tooltip content is a description, not an accessible name).