### PR TITLE
fix(ui): add empty and not-found states to share lists and admin user page

### DIFF
--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import * as Empty from '$lib/components/ui/empty';
+  import { cn } from '$lib/utils';
+  import type { Component, Snippet } from 'svelte';
+
+  interface Props {
+    /** Icon component (e.g. a lucide icon) rendered in the media slot. */
+    icon: Component;
+    title: string;
+    description?: string;
+    /** `default` fills/centers the available space; `compact` is a small bordered box. */
+    compact?: boolean;
+    class?: string;
+    /** Optional action area (e.g. a button), rendered below the text. */
+    children?: Snippet;
+  }
+
+  let { icon: Icon, title, description, compact, class: className, children }: Props = $props();
+</script>
+
+<Empty.Root class={cn(compact ? 'flex-none rounded-md border' : 'gap-6 py-12 sm:gap-8', className)}>
+  <Empty.Header class={compact ? undefined : 'gap-3'}>
+    <Empty.Media
+      variant="icon"
+      class={compact
+        ? undefined
+        : "size-16 rounded-2xl sm:size-20 [&_svg:not([class*='size-'])]:size-8 sm:[&_svg:not([class*='size-'])]:size-10"}
+    >
+      <Icon />
+    </Empty.Media>
+    <Empty.Title class={compact ? undefined : 'text-xl sm:text-2xl'}>{title}</Empty.Title>
+    {#if description}
+      <Empty.Description class={compact ? undefined : 'text-base sm:text-lg'}>
+        {description}
+      </Empty.Description>
+    {/if}
+  </Empty.Header>
+  {#if children}
+    <Empty.Content>
+      {@render children()}
+    </Empty.Content>
+  {/if}
+</Empty.Root>

--- a/src/lib/components/ui/empty/empty-content.svelte
+++ b/src/lib/components/ui/empty/empty-content.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-content"
+	class={cn(
+		"gap-2.5 text-sm flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/empty-description.svelte
+++ b/src/lib/components/ui/empty/empty-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-description"
+	class={cn(
+		"text-sm/relaxed text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/empty-header.svelte
+++ b/src/lib/components/ui/empty/empty-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-header"
+	class={cn("gap-2 flex max-w-sm flex-col items-center", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/empty-media.svelte
+++ b/src/lib/components/ui/empty/empty-media.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+
+	export const emptyMediaVariants = tv({
+		base: "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		variants: {
+			variant: {
+				default: "bg-transparent",
+				icon: "bg-muted text-foreground flex size-8 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-4",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type EmptyMediaVariant = VariantProps<typeof emptyMediaVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		variant = "default",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & { variant?: EmptyMediaVariant } = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-icon"
+	data-variant={variant}
+	class={cn(emptyMediaVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/empty-title.svelte
+++ b/src/lib/components/ui/empty/empty-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty-title"
+	class={cn("text-sm font-medium tracking-tight", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/empty.svelte
+++ b/src/lib/components/ui/empty/empty.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils/shadcn.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="empty"
+	class={cn(
+		"gap-4 rounded-xl border-dashed p-6 flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/empty/index.ts
+++ b/src/lib/components/ui/empty/index.ts
@@ -1,0 +1,22 @@
+import Root from "./empty.svelte";
+import Header from "./empty-header.svelte";
+import Media from "./empty-media.svelte";
+import Title from "./empty-title.svelte";
+import Description from "./empty-description.svelte";
+import Content from "./empty-content.svelte";
+
+export {
+	Root,
+	Header,
+	Media,
+	Title,
+	Description,
+	Content,
+	//
+	Root as Empty,
+	Header as EmptyHeader,
+	Media as EmptyMedia,
+	Title as EmptyTitle,
+	Description as EmptyDescription,
+	Content as EmptyContent,
+};

--- a/src/routes/(app)/admin/users/[userId]/+page.svelte
+++ b/src/routes/(app)/admin/users/[userId]/+page.svelte
@@ -3,7 +3,7 @@
   import { adminGetUsers } from '$lib/api';
   import type { AdminUsersView, AdminUsersViewPaginated } from '$lib/api';
   import Container from '$lib/components/Container.svelte';
-  import * as Empty from '$lib/components/ui/empty';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -42,15 +42,7 @@
       <span class="text-muted-foreground">Loading user...</span>
     </div>
   {:else if !user}
-    <Empty.Root>
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <UserX />
-        </Empty.Media>
-        <Empty.Title>User not found</Empty.Title>
-        <Empty.Description>No user found with this ID.</Empty.Description>
-      </Empty.Header>
-    </Empty.Root>
+    <EmptyState icon={UserX} title="User not found" description="No user found with this ID." />
   {:else}
     {user.name}
   {/if}

--- a/src/routes/(app)/admin/users/[userId]/+page.svelte
+++ b/src/routes/(app)/admin/users/[userId]/+page.svelte
@@ -3,14 +3,16 @@
   import { adminGetUsers } from '$lib/api';
   import type { AdminUsersView, AdminUsersViewPaginated } from '$lib/api';
   import Container from '$lib/components/Container.svelte';
+  import { Spinner } from '$lib/components/ui/spinner';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
 
   let user = $state<AdminUsersView | null>(null);
+  let loading = $state(true);
 
   registerBreadcrumbs(() => [
     { label: 'Users', href: '/admin/users' },
-    { label: user?.name ?? 'Loading...' },
+    { label: user?.name ?? (loading ? 'Loading...' : 'Not found') },
   ]);
 
   function handleResponse(page: AdminUsersViewPaginated) {
@@ -23,12 +25,23 @@
   }
 
   $effect(() => {
+    loading = true;
     adminGetUsers({ query: { $filter: 'id eq ' + page.params.userId } })
       .then(handleResponse)
-      .catch(handleApiError);
+      .catch(handleApiError)
+      .finally(() => (loading = false));
   });
 </script>
 
 <Container>
-  {user?.name ?? 'Loading...'}
+  {#if loading}
+    <div class="flex items-center gap-3 p-12">
+      <Spinner class="size-5" />
+      <span class="text-muted-foreground">Loading user...</span>
+    </div>
+  {:else if !user}
+    <p class="text-muted-foreground p-12">No user found with this ID.</p>
+  {:else}
+    {user.name}
+  {/if}
 </Container>

--- a/src/routes/(app)/admin/users/[userId]/+page.svelte
+++ b/src/routes/(app)/admin/users/[userId]/+page.svelte
@@ -3,9 +3,11 @@
   import { adminGetUsers } from '$lib/api';
   import type { AdminUsersView, AdminUsersViewPaginated } from '$lib/api';
   import Container from '$lib/components/Container.svelte';
+  import * as Empty from '$lib/components/ui/empty';
   import { Spinner } from '$lib/components/ui/spinner';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
+  import UserX from '@lucide/svelte/icons/user-x';
 
   let user = $state<AdminUsersView | null>(null);
   let loading = $state(true);
@@ -40,7 +42,15 @@
       <span class="text-muted-foreground">Loading user...</span>
     </div>
   {:else if !user}
-    <p class="text-muted-foreground p-12">No user found with this ID.</p>
+    <Empty.Root>
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <UserX />
+        </Empty.Media>
+        <Empty.Title>User not found</Empty.Title>
+        <Empty.Description>No user found with this ID.</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
   {:else}
     {user.name}
   {/if}

--- a/src/routes/(app)/settings/connections/+page.svelte
+++ b/src/routes/(app)/settings/connections/+page.svelte
@@ -10,6 +10,7 @@
   import Container from '$lib/components/Container.svelte';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import * as Dropdown from '$lib/components/ui/dropdown-menu';
   import * as Separator from '$lib/components/ui/separator';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
@@ -111,7 +112,7 @@
     </Card.Description>
   </Card.Header>
 
-  <Card.Content class="w-full space-y-6">
+  <Card.Content class="flex w-full flex-1 flex-col space-y-6">
     <!-- Quick actions -->
     <div class="flex flex-wrap gap-2">
       <Dropdown.Root>
@@ -162,12 +163,11 @@
         {/each}
       </div>
     {:else if connections.length === 0}
-      <div class="rounded-xl border p-6 text-sm">
-        <div class="mb-2 font-medium">No connections yet</div>
-        <div class="text-muted-foreground">
-          Choose “Link new provider” above to connect available providers.
-        </div>
-      </div>
+      <EmptyState
+        icon={Link2}
+        title="No connections yet"
+        description="Choose “Link new provider” above to connect available providers."
+      />
     {:else}
       <div class="grid gap-3 md:grid-cols-2">
         {#each backendMetadata.state!.oAuthProviders as p (p)}

--- a/src/routes/(app)/shares/public/+page.svelte
+++ b/src/routes/(app)/shares/public/+page.svelte
@@ -11,6 +11,7 @@
   import type { OwnPublicShareResponse } from '$lib/api';
   import Container from '$lib/components/Container.svelte';
   import CopyInput from '$lib/components/CopyInput.svelte';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
   import Button from '$lib/components/ui/button/button.svelte';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
@@ -93,19 +94,16 @@
       <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
     </div>
   {:else if sortedShares.length === 0}
-    <div
-      class="border-border/60 text-muted-foreground flex w-full flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-16"
+    <EmptyState
+      icon={Link2}
+      title="No public shares yet"
+      description="Create a link that anyone can use to control your shockers."
     >
-      <Link2 class="size-10 opacity-50" />
-      <div class="text-center">
-        <p class="text-foreground text-sm font-medium">No public shares yet</p>
-        <p class="mt-1 text-xs">Create a link that anyone can use to control your shockers.</p>
-      </div>
-      <Button onclick={() => (showAddShareModal = true)} size="sm">
+      <Button size="lg" onclick={() => (showAddShareModal = true)}>
         <Plus />
         New Share
       </Button>
-    </div>
+    </EmptyState>
   {:else}
     <div
       class="grid w-full grid-cols-1 gap-4 sm:[grid-template-columns:repeat(auto-fill,minmax(18rem,1fr))]"

--- a/src/routes/(app)/shares/user/+layout.svelte
+++ b/src/routes/(app)/shares/user/+layout.svelte
@@ -117,7 +117,7 @@
     </Tabs.Root>
   </div>
 
-  <div class="flex w-full flex-col space-y-4 overflow-auto">
+  <div class="flex w-full flex-1 flex-col space-y-4 overflow-auto">
     {@render children?.()}
   </div>
 </Container>

--- a/src/routes/(app)/shares/user/incoming/+page.svelte
+++ b/src/routes/(app)/shares/user/incoming/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import * as Empty from '$lib/components/ui/empty';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
   import { userSharesState, refreshUserShares } from '$lib/state/user-shares-state.svelte';
+  import Inbox from '@lucide/svelte/icons/inbox';
   import IncomingShareItem from './incoming-share-item.svelte';
   import ManageShare from './manage-share.svelte';
 
@@ -32,21 +34,27 @@
     <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
   </div>
 {:then}
-  <div class="mb-6 overflow-y-auto rounded-md border">
-    <Table.Root>
-      <Table.Body>
-        {#each userSharesState.shares.incoming as incomingShare, i (incomingShare.id)}
-          <IncomingShareItem share={incomingShare} onOpenEdit={() => openManageDrawer(i)} />
-        {:else}
-          <Table.Row>
-            <Table.Cell class="text-muted-foreground py-8 text-center">
-              No one has shared a shocker with you yet.
-            </Table.Cell>
-          </Table.Row>
-        {/each}
-      </Table.Body>
-    </Table.Root>
-  </div>
+  {#if userSharesState.shares.incoming.length === 0}
+    <Empty.Root class="mb-6 rounded-md border">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <Inbox />
+        </Empty.Media>
+        <Empty.Title>Nothing shared with you</Empty.Title>
+        <Empty.Description>No one has shared a shocker with you yet.</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
+  {:else}
+    <div class="mb-6 overflow-y-auto rounded-md border">
+      <Table.Root>
+        <Table.Body>
+          {#each userSharesState.shares.incoming as incomingShare, i (incomingShare.id)}
+            <IncomingShareItem share={incomingShare} onOpenEdit={() => openManageDrawer(i)} />
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  {/if}
 {:catch error}
   <div class="text-red-500">Failed to load outgoing invites: {error.message}</div>
 {/await}

--- a/src/routes/(app)/shares/user/incoming/+page.svelte
+++ b/src/routes/(app)/shares/user/incoming/+page.svelte
@@ -37,6 +37,12 @@
       <Table.Body>
         {#each userSharesState.shares.incoming as incomingShare, i (incomingShare.id)}
           <IncomingShareItem share={incomingShare} onOpenEdit={() => openManageDrawer(i)} />
+        {:else}
+          <Table.Row>
+            <Table.Cell class="text-muted-foreground py-8 text-center">
+              No one has shared a shocker with you yet.
+            </Table.Cell>
+          </Table.Row>
         {/each}
       </Table.Body>
     </Table.Root>

--- a/src/routes/(app)/shares/user/incoming/+page.svelte
+++ b/src/routes/(app)/shares/user/incoming/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as Empty from '$lib/components/ui/empty';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -35,15 +35,11 @@
   </div>
 {:then}
   {#if userSharesState.shares.incoming.length === 0}
-    <Empty.Root class="mb-6 rounded-md border">
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <Inbox />
-        </Empty.Media>
-        <Empty.Title>Nothing shared with you</Empty.Title>
-        <Empty.Description>No one has shared a shocker with you yet.</Empty.Description>
-      </Empty.Header>
-    </Empty.Root>
+    <EmptyState
+      icon={Inbox}
+      title="Nothing shared with you"
+      description="No one has shared a shocker with you yet."
+    />
   {:else}
     <div class="mb-6 overflow-y-auto rounded-md border">
       <Table.Root>

--- a/src/routes/(app)/shares/user/invites/+page.svelte
+++ b/src/routes/(app)/shares/user/invites/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import * as Empty from '$lib/components/ui/empty';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -7,6 +8,8 @@
     refreshIncomingInvites,
     refreshOutgoingInvites,
   } from '$lib/state/user-shares-state.svelte';
+  import MailPlus from '@lucide/svelte/icons/mail-plus';
+  import Mail from '@lucide/svelte/icons/mail';
   import IncomingInviteItem from './incoming-invite-item.svelte';
   import OutgoingInviteItem from './outgoing-invite-item.svelte';
 
@@ -23,21 +26,27 @@
     <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
   </div>
 {:then}
-  <div class="mb-6 overflow-y-auto rounded-md border">
-    <Table.Root>
-      <Table.Body>
-        {#each userSharesState.outgoingInvites as invite (invite.id)}
-          <OutgoingInviteItem shareInvite={invite} />
-        {:else}
-          <Table.Row>
-            <Table.Cell class="text-muted-foreground py-8 text-center">
-              You have no outgoing share invites.
-            </Table.Cell>
-          </Table.Row>
-        {/each}
-      </Table.Body>
-    </Table.Root>
-  </div>
+  {#if userSharesState.outgoingInvites.length === 0}
+    <Empty.Root class="mb-6 rounded-md border">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <MailPlus />
+        </Empty.Media>
+        <Empty.Title>No outgoing invites</Empty.Title>
+        <Empty.Description>You have no outgoing share invites.</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
+  {:else}
+    <div class="mb-6 overflow-y-auto rounded-md border">
+      <Table.Root>
+        <Table.Body>
+          {#each userSharesState.outgoingInvites as invite (invite.id)}
+            <OutgoingInviteItem shareInvite={invite} />
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  {/if}
 {:catch error}
   <div class="text-red-500">Failed to load outgoing invites: {error.message}</div>
 {/await}
@@ -49,21 +58,27 @@
     <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
   </div>
 {:then}
-  <div class="mb-6 overflow-y-auto rounded-md border">
-    <Table.Root>
-      <Table.Body>
-        {#each userSharesState.incomingInvites as invite (invite.id)}
-          <IncomingInviteItem shareInvite={invite} />
-        {:else}
-          <Table.Row>
-            <Table.Cell class="text-muted-foreground py-8 text-center">
-              You have no incoming share invites.
-            </Table.Cell>
-          </Table.Row>
-        {/each}
-      </Table.Body>
-    </Table.Root>
-  </div>
+  {#if userSharesState.incomingInvites.length === 0}
+    <Empty.Root class="mb-6 rounded-md border">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <Mail />
+        </Empty.Media>
+        <Empty.Title>No incoming invites</Empty.Title>
+        <Empty.Description>You have no incoming share invites.</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
+  {:else}
+    <div class="mb-6 overflow-y-auto rounded-md border">
+      <Table.Root>
+        <Table.Body>
+          {#each userSharesState.incomingInvites as invite (invite.id)}
+            <IncomingInviteItem shareInvite={invite} />
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  {/if}
 {:catch error}
   <div class="text-red-500">Failed to load incoming invites: {error.message}</div>
 {/await}

--- a/src/routes/(app)/shares/user/invites/+page.svelte
+++ b/src/routes/(app)/shares/user/invites/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as Empty from '$lib/components/ui/empty';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -15,70 +15,67 @@
 
   registerBreadcrumbs(() => [{ label: 'Invites' }]);
 
-  let outgoingInvitesPromise = $state(refreshOutgoingInvites());
-  let incomingInvitesPromise = $state(refreshIncomingInvites());
+  let invitesPromise = $state(Promise.all([refreshOutgoingInvites(), refreshIncomingInvites()]));
+
+  let bothEmpty = $derived(
+    userSharesState.outgoingInvites.length === 0 && userSharesState.incomingInvites.length === 0
+  );
 </script>
 
-<h2 class="text-3xl font-semibold">Outgoing</h2>
-
-{#await outgoingInvitesPromise}
+{#await invitesPromise}
   <div class="flex h-full w-full items-center justify-center">
     <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
   </div>
 {:then}
-  {#if userSharesState.outgoingInvites.length === 0}
-    <Empty.Root class="mb-6 rounded-md border">
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <MailPlus />
-        </Empty.Media>
-        <Empty.Title>No outgoing invites</Empty.Title>
-        <Empty.Description>You have no outgoing share invites.</Empty.Description>
-      </Empty.Header>
-    </Empty.Root>
+  {#if bothEmpty}
+    <EmptyState
+      icon={Mail}
+      title="No invites yet"
+      description="You have no incoming or outgoing share invites."
+    />
   {:else}
-    <div class="mb-6 overflow-y-auto rounded-md border">
-      <Table.Root>
-        <Table.Body>
-          {#each userSharesState.outgoingInvites as invite (invite.id)}
-            <OutgoingInviteItem shareInvite={invite} />
-          {/each}
-        </Table.Body>
-      </Table.Root>
-    </div>
+    <h2 class="text-3xl font-semibold">Outgoing</h2>
+    {#if userSharesState.outgoingInvites.length === 0}
+      <EmptyState
+        compact
+        icon={MailPlus}
+        title="No outgoing invites"
+        description="You have no outgoing share invites."
+        class="mb-6"
+      />
+    {:else}
+      <div class="mb-6 overflow-y-auto rounded-md border">
+        <Table.Root>
+          <Table.Body>
+            {#each userSharesState.outgoingInvites as invite (invite.id)}
+              <OutgoingInviteItem shareInvite={invite} />
+            {/each}
+          </Table.Body>
+        </Table.Root>
+      </div>
+    {/if}
+
+    <h2 class="text-3xl font-semibold">Incoming</h2>
+    {#if userSharesState.incomingInvites.length === 0}
+      <EmptyState
+        compact
+        icon={Mail}
+        title="No incoming invites"
+        description="You have no incoming share invites."
+        class="mb-6"
+      />
+    {:else}
+      <div class="mb-6 overflow-y-auto rounded-md border">
+        <Table.Root>
+          <Table.Body>
+            {#each userSharesState.incomingInvites as invite (invite.id)}
+              <IncomingInviteItem shareInvite={invite} />
+            {/each}
+          </Table.Body>
+        </Table.Root>
+      </div>
+    {/if}
   {/if}
 {:catch error}
-  <div class="text-red-500">Failed to load outgoing invites: {error.message}</div>
-{/await}
-
-<h2 class="text-3xl font-semibold">Incoming</h2>
-
-{#await incomingInvitesPromise}
-  <div class="flex h-full w-full items-center justify-center">
-    <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
-  </div>
-{:then}
-  {#if userSharesState.incomingInvites.length === 0}
-    <Empty.Root class="mb-6 rounded-md border">
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <Mail />
-        </Empty.Media>
-        <Empty.Title>No incoming invites</Empty.Title>
-        <Empty.Description>You have no incoming share invites.</Empty.Description>
-      </Empty.Header>
-    </Empty.Root>
-  {:else}
-    <div class="mb-6 overflow-y-auto rounded-md border">
-      <Table.Root>
-        <Table.Body>
-          {#each userSharesState.incomingInvites as invite (invite.id)}
-            <IncomingInviteItem shareInvite={invite} />
-          {/each}
-        </Table.Body>
-      </Table.Root>
-    </div>
-  {/if}
-{:catch error}
-  <div class="text-red-500">Failed to load incoming invites: {error.message}</div>
+  <div class="text-red-500">Failed to load invites: {error.message}</div>
 {/await}

--- a/src/routes/(app)/shares/user/invites/+page.svelte
+++ b/src/routes/(app)/shares/user/invites/+page.svelte
@@ -28,6 +28,12 @@
       <Table.Body>
         {#each userSharesState.outgoingInvites as invite (invite.id)}
           <OutgoingInviteItem shareInvite={invite} />
+        {:else}
+          <Table.Row>
+            <Table.Cell class="text-muted-foreground py-8 text-center">
+              You have no outgoing share invites.
+            </Table.Cell>
+          </Table.Row>
         {/each}
       </Table.Body>
     </Table.Root>
@@ -48,10 +54,16 @@
       <Table.Body>
         {#each userSharesState.incomingInvites as invite (invite.id)}
           <IncomingInviteItem shareInvite={invite} />
+        {:else}
+          <Table.Row>
+            <Table.Cell class="text-muted-foreground py-8 text-center">
+              You have no incoming share invites.
+            </Table.Cell>
+          </Table.Row>
         {/each}
       </Table.Body>
     </Table.Root>
   </div>
 {:catch error}
-  <div class="text-red-500">Failed to load incomding invites: {error.message}</div>
+  <div class="text-red-500">Failed to load incoming invites: {error.message}</div>
 {/await}

--- a/src/routes/(app)/shares/user/outgoing/+page.svelte
+++ b/src/routes/(app)/shares/user/outgoing/+page.svelte
@@ -36,6 +36,12 @@
       <Table.Body>
         {#each userSharesState.shares.outgoing as userShare, i (userShare.id)}
           <UserShareItem storeIndex={i} onOpenEdit={() => openEditDrawer(i)} />
+        {:else}
+          <Table.Row>
+            <Table.Cell class="text-muted-foreground py-8 text-center">
+              You haven't shared any shockers with other users yet.
+            </Table.Cell>
+          </Table.Row>
         {/each}
       </Table.Body>
     </Table.Root>

--- a/src/routes/(app)/shares/user/outgoing/+page.svelte
+++ b/src/routes/(app)/shares/user/outgoing/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as Empty from '$lib/components/ui/empty';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -34,15 +34,11 @@
   </div>
 {:then}
   {#if userSharesState.shares.outgoing.length === 0}
-    <Empty.Root class="mb-6 rounded-md border">
-      <Empty.Header>
-        <Empty.Media variant="icon">
-          <Share2 />
-        </Empty.Media>
-        <Empty.Title>No shared shockers</Empty.Title>
-        <Empty.Description>You haven't shared any shockers with other users yet.</Empty.Description>
-      </Empty.Header>
-    </Empty.Root>
+    <EmptyState
+      icon={Share2}
+      title="No shared shockers"
+      description="You haven't shared any shockers with other users yet."
+    />
   {:else}
     <div class="mb-6 overflow-y-auto rounded-md border">
       <Table.Root>

--- a/src/routes/(app)/shares/user/outgoing/+page.svelte
+++ b/src/routes/(app)/shares/user/outgoing/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import * as Empty from '$lib/components/ui/empty';
   import { Spinner } from '$lib/components/ui/spinner';
   import * as Table from '$lib/components/ui/table';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
   import { userSharesState, refreshUserShares } from '$lib/state/user-shares-state.svelte';
+  import Share2 from '@lucide/svelte/icons/share-2';
   import EditShare from './edit-share.svelte';
   import UserShareItem from './user-share-item.svelte';
 
@@ -31,21 +33,27 @@
     <Spinner class="size-8 text-gray-600 dark:text-gray-300" />
   </div>
 {:then}
-  <div class="mb-6 overflow-y-auto rounded-md border">
-    <Table.Root>
-      <Table.Body>
-        {#each userSharesState.shares.outgoing as userShare, i (userShare.id)}
-          <UserShareItem storeIndex={i} onOpenEdit={() => openEditDrawer(i)} />
-        {:else}
-          <Table.Row>
-            <Table.Cell class="text-muted-foreground py-8 text-center">
-              You haven't shared any shockers with other users yet.
-            </Table.Cell>
-          </Table.Row>
-        {/each}
-      </Table.Body>
-    </Table.Root>
-  </div>
+  {#if userSharesState.shares.outgoing.length === 0}
+    <Empty.Root class="mb-6 rounded-md border">
+      <Empty.Header>
+        <Empty.Media variant="icon">
+          <Share2 />
+        </Empty.Media>
+        <Empty.Title>No shared shockers</Empty.Title>
+        <Empty.Description>You haven't shared any shockers with other users yet.</Empty.Description>
+      </Empty.Header>
+    </Empty.Root>
+  {:else}
+    <div class="mb-6 overflow-y-auto rounded-md border">
+      <Table.Root>
+        <Table.Body>
+          {#each userSharesState.shares.outgoing as userShare, i (userShare.id)}
+            <UserShareItem storeIndex={i} onOpenEdit={() => openEditDrawer(i)} />
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  {/if}
 {:catch error}
   <div class="text-red-500">Failed to load shares: {error.message}</div>
 {/await}

--- a/src/routes/(app)/shockers/own/+page.svelte
+++ b/src/routes/(app)/shockers/own/+page.svelte
@@ -7,6 +7,7 @@
   import { resolve } from '$app/paths';
   import Container from '$lib/components/Container.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import ClassicControlModule from '$lib/components/ControlModules/ClassicControlModule.svelte';
   import DialogShockerAdd, {
     defaultAddShockerData,
@@ -297,22 +298,23 @@
     <hr class="border-border" />
 
     {#if shockers.length === 0}
-      <div class="flex flex-col items-center justify-center gap-4 py-16">
-        <Zap class="text-muted-foreground size-12" />
-        <div class="text-center">
-          <h2 class="text-lg font-semibold">No shockers yet</h2>
-          <p class="text-muted-foreground text-sm">
-            {#if ownHubs.size === 0}
-              Create a hub first, then add shockers to it.
-            {:else}
-              Add a shocker to one of your hubs to get started.
-            {/if}
-          </p>
-        </div>
-        <Button onclick={openAddShockerDialog} disabled={ownHubs.size === 0}>
-          <Plus class="size-4" /> Add Shocker
-        </Button>
-      </div>
+      <EmptyState
+        icon={Zap}
+        title="No shockers yet"
+        description={ownHubs.size === 0
+          ? 'Create a hub first, then add shockers to it.'
+          : 'Add a shocker to one of your hubs to get started.'}
+      >
+        {#if ownHubs.size === 0}
+          <Button size="lg" href={resolve('/hubs')}>
+            <Plus class="size-4" /> Create a Hub
+          </Button>
+        {:else}
+          <Button size="lg" onclick={openAddShockerDialog}>
+            <Plus class="size-4" /> Add Shocker
+          </Button>
+        {/if}
+      </EmptyState>
     {:else}
       {#if moduleType === ModuleType.SimpleControlModule}
         <SimpleControlHeader bind:shockIntensity bind:vibrationIntensity bind:duration />

--- a/src/routes/(app)/shockers/shared/+page.svelte
+++ b/src/routes/(app)/shockers/shared/+page.svelte
@@ -8,6 +8,7 @@
   import * as Avatar from '$lib/components/ui/avatar';
   import { Button } from '$lib/components/ui/button';
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { copyToClipboard } from '$lib/utils/clipboard.svelte';
   import { onlineHubs } from '$lib/state/hubs-state.svelte';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
@@ -65,11 +66,11 @@
     <PageHeader title="Shared Shockers" subtitle="Manage shared shockers with other users" />
 
     {#if !hasSharedShockers}
-      <div class="text-muted-foreground flex flex-col items-center justify-center py-12">
-        <User size={48} class="mb-4 opacity-50" />
-        <p class="text-lg">No shockers have been shared with you yet.</p>
-        <p class="text-sm">When someone shares their shockers with you, they'll appear here.</p>
-      </div>
+      <EmptyState
+        icon={User}
+        title="No shockers have been shared with you yet."
+        description="When someone shares their shockers with you, they'll appear here."
+      />
     {:else}
       <div class="flex w-full flex-col gap-5">
         {#each sharedHubsState.value as owner (owner.id)}


### PR DESCRIPTION
The hand-rolled share list pages (outgoing/incoming/invites) rendered an empty bordered box when there was nothing to show; add {:else} empty-state copy. The admin user detail page showed 'Loading...' forever on a 404; add proper loading and not-found states. Also fix an 'incomding' typo.