### PR TITLE
fix(error-handling): route API failures through handleApiError

### DIFF
--- a/src/lib/api/pwnedPasswords.ts
+++ b/src/lib/api/pwnedPasswords.ts
@@ -12,6 +12,10 @@ export async function checkPwnedCount(password: string): Promise<number> {
   try {
     const response = await fetch(`https://api.pwnedpasswords.com/range/${hashPrefix}`);
 
+    if (!response.ok) {
+      throw new Error(`Pwned passwords range request failed with status ${response.status}`);
+    }
+
     raw = await response.text();
   } catch (error) {
     throw new Error('Error while fetching pwned passwords range', { cause: error });

--- a/src/lib/components/FirmwareChannelSelector.svelte
+++ b/src/lib/components/FirmwareChannelSelector.svelte
@@ -6,6 +6,7 @@
     FirmwareChannels,
   } from '$lib/api/firmwareCDN';
   import * as ToggleGroup from '$lib/components/ui/toggle-group';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
 
   /** Optional chip to constrain the list of boards to */
   //export let chip: string | null = null;
@@ -41,10 +42,12 @@
     const currentChannel = channel;
 
     // Fetch the channel version from the API.
-    FetchChannelVersion(currentChannel).then((ver) => {
-      version = ver ?? null;
-      versions[currentChannel] = version;
-    });
+    FetchChannelVersion(currentChannel)
+      .then((ver) => {
+        version = ver ?? null;
+        versions[currentChannel] = version;
+      })
+      .catch(handleApiError);
   });
 </script>
 

--- a/src/lib/components/shares/user-selector.svelte
+++ b/src/lib/components/shares/user-selector.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { Check, Search } from '@lucide/svelte';
-  import { usersGetByName } from '$lib/api';
+  import { ResponseError, usersGetByName } from '$lib/api';
   import type { BasicUserInfo } from '$lib/api';
   import * as Avatar from '$lib/components/ui/avatar';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input/index.js';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
 
   interface Props {
     fetchedUser: BasicUserInfo | null;
@@ -20,8 +21,13 @@
         fetchedUser = user;
         userInput = user.name;
       })
-      .catch(() => {
+      .catch((error) => {
         fetchedUser = null;
+        // A 404 just means no user by that name — expected, no toast.
+        // Surface anything else (network/server errors) to the user.
+        if (!(error instanceof ResponseError && error.response.status === 404)) {
+          handleApiError(error);
+        }
       });
   }
 

--- a/src/lib/components/utils/MultiPauseToggle.svelte
+++ b/src/lib/components/utils/MultiPauseToggle.svelte
@@ -4,7 +4,7 @@
   import { Asterisk, Pause, Play } from '@lucide/svelte';
   import { Button } from '$lib/components/ui/button';
   import { Spinner } from '$lib/components/ui/spinner';
-  import { toast } from 'svelte-sonner';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
 
   interface Props {
     shockers: PauseToggleProps[];
@@ -44,10 +44,7 @@
     }
 
     Promise.all(pauseRequests)
-      .catch((error) => {
-        toast.error(`Failed to update shocker states`);
-        console.error(error);
-      })
+      .catch(handleApiError)
       .finally(() => {
         requestInProgress = false;
         onPausedChange(pause);
@@ -69,16 +66,8 @@
       });
     }
 
-    pauseRequest
-      .then((newPausedState) => {
-        shocker.paused = newPausedState.data;
-      })
-      .catch((error) => {
-        toast.error(`Failed to set shocker pause state`);
-        console.error(error);
-      });
-
-    await pauseRequest;
+    const newPausedState = await pauseRequest;
+    shocker.paused = newPausedState.data;
   }
 </script>
 

--- a/src/lib/components/utils/PauseToggle.svelte
+++ b/src/lib/components/utils/PauseToggle.svelte
@@ -4,7 +4,7 @@
   import { Pause, Play } from '@lucide/svelte';
   import { Button } from '$lib/components/ui/button';
   import { Spinner } from '$lib/components/ui/spinner';
-  import { toast } from 'svelte-sonner';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
 
   interface Props {
     shockerId: string;
@@ -37,10 +37,7 @@
       .then((newPausedState) => {
         paused = newPausedState.data;
       })
-      .catch((error) => {
-        toast.error(`Failed to toggle pause state: ${error.message}`);
-        console.error(error);
-      })
+      .catch(handleApiError)
       .finally(() => {
         requestInProgress = false;
         onPausedChange(paused);

--- a/src/routes/(app)/shares/public/dialog-publicshare-delete.svelte
+++ b/src/routes/(app)/shares/public/dialog-publicshare-delete.svelte
@@ -2,6 +2,7 @@
   import { shareLinksDeletePublicShare } from '$lib/api';
   import type { OwnPublicShareResponse } from '$lib/api';
   import ConfirmDeleteDialog from '$lib/components/ConfirmDeleteDialog.svelte';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
   import { toast } from 'svelte-sonner';
 
   interface Props {
@@ -18,6 +19,7 @@
         onDeleted();
         toast.success('Deleted publicShare successfully');
       })
+      .catch(handleApiError)
       .finally(() => {
         open = false;
       });

--- a/src/routes/(app)/shares/user/outgoing/edit-share.svelte
+++ b/src/routes/(app)/shares/user/outgoing/edit-share.svelte
@@ -135,9 +135,7 @@
               };
             }
           })
-          .catch((error) => {
-            toast.error(`Failed to update share ${share.id}: ${error.message}`);
-          })
+          .catch(handleApiError)
       );
     });
 

--- a/src/routes/(auth)/oauth/[provider]/create/+page.svelte
+++ b/src/routes/(auth)/oauth/[provider]/create/+page.svelte
@@ -8,7 +8,6 @@
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card/index.js';
   import { FieldDescription } from '$lib/components/ui/field/index.js';
-  import { isValidationError, mapToValRes } from '$lib/errorhandling/ValidationProblemDetails';
   import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
   import { registerBreadcrumbs } from '$lib/state/breadcrumbs-state.svelte';
   import { userState } from '$lib/state/user-state.svelte';
@@ -56,16 +55,8 @@
 
       goto(resolve('/home'));
     } catch (error) {
-      await handleApiError(error, (problem) => {
-        if (!isValidationError(problem)) return false;
-
-        console.log(mapToValRes(problem, 'Username'));
-        console.log(mapToValRes(problem, 'Password'));
-        console.log(mapToValRes(problem, 'Email'));
-        console.log(mapToValRes(problem, 'TurnstileResponse'));
-
-        return true;
-      });
+      // Let handleApiError surface validation messages via its generic toast.
+      await handleApiError(error);
     }
   }
 
@@ -81,8 +72,8 @@
           emailValid = true;
         }
       })
-      .catch((err) => {
-        console.error('Failed to fetch OAuth signup data', err);
+      .catch(async (err) => {
+        await handleApiError(err);
         goto(resolve('/login'));
       });
   });


### PR DESCRIPTION
Close several spots where API failures were swallowed or surfaced inconsistently:
- dialog-publicshare-delete: add missing .catch (was an unhandled rejection)
- FirmwareChannelSelector: catch channel-version fetch failures
- user-selector: surface non-404 errors instead of treating every failure as 'user not found'
- pwnedPasswords: throw on non-ok response instead of silently returning 0
- oauth signup create: drop dead console.log debug and let handleApiError surface validation messages; surface signup-data fetch errors
- PauseToggle / MultiPauseToggle / edit-share: use handleApiError instead of hand-rolled toasts that leaked raw error.message and bypassed the 401 hook; fixes a double-toast in MultiPauseToggle