### PR TITLE
feat(admin): implement delete-user action

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -32,6 +32,7 @@ export {
   adminConfigurationDelete,
   adminConfigurationList,
   adminConfigurationUpdate,
+  adminDeleteUser,
   adminGetOnlineDevices,
   adminGetUsers,
   adminListEmailProviderBlacklist,

--- a/src/routes/(app)/admin/users/+page.svelte
+++ b/src/routes/(app)/admin/users/+page.svelte
@@ -25,7 +25,7 @@
     return isPrivileged ? RenderBlueCell(roles.toString()) : RenderBoldCell(roles.toString());
   };
 
-  const columns: ColumnDef<AdminUsersView>[] = [
+  const dataColumns: ColumnDef<AdminUsersView>[] = [
     CreateSortableColumnDef('name', 'Name', RenderCell),
     CreateSortableColumnDef('email', 'Email', RenderCell),
     CreateSortableColumnDef('passwordHashType', 'Password hash type', PasswordHashTypeRenderer),
@@ -36,7 +36,6 @@
     CreateSortableColumnDef('deactivatedByUserId', 'Deactivated by', (a) =>
       a ? RenderCell(a) : RenderRedCell('None')
     ),
-    CreateActionsColumnDef(DataTableActions, (user) => ({ user })),
   ];
 
   function escapeQuotes(str: string) {
@@ -80,6 +79,17 @@
   registerBreadcrumbs(() => [{ label: 'Users' }]);
 
   let isFetching = $state(false);
+
+  // Bumped to force a re-fetch after a mutation (e.g. user deletion).
+  let refreshNonce = $state(0);
+
+  const columns: ColumnDef<AdminUsersView>[] = [
+    ...dataColumns,
+    CreateActionsColumnDef(DataTableActions, (user) => ({
+      user,
+      onDeleted: () => refreshNonce++,
+    })),
+  ];
 
   let requestedPage = $state(1);
   let requestedPageSize = $state(100);
@@ -126,6 +136,7 @@
   });
 
   $effect(() => {
+    void refreshNonce; // re-run after a mutation
     const offset = (requestedPage - 1) * requestedPageSize;
 
     isFetching = true;

--- a/src/routes/(app)/admin/users/data-table-actions.svelte
+++ b/src/routes/(app)/admin/users/data-table-actions.svelte
@@ -10,9 +10,10 @@
 
   interface Props {
     user: AdminUsersView;
+    onDeleted?: () => void;
   }
 
-  let { user }: Props = $props();
+  let { user, onDeleted }: Props = $props();
 
   let editDialogOpen = $state<boolean>(false);
   let deleteDialogOpen = $state<boolean>(false);
@@ -24,7 +25,7 @@
 </script>
 
 <UserEditDialog bind:open={editDialogOpen} {user} />
-<UserDeleteDialog bind:open={deleteDialogOpen} {user} />
+<UserDeleteDialog bind:open={deleteDialogOpen} {user} {onDeleted} />
 
 <TableActionMenu>
   <DropdownMenu.Label>User</DropdownMenu.Label>

--- a/src/routes/(app)/admin/users/dialog-user-delete.svelte
+++ b/src/routes/(app)/admin/users/dialog-user-delete.svelte
@@ -1,16 +1,30 @@
 <script lang="ts">
+  import { adminDeleteUser } from '$lib/api';
   import type { AdminUsersView } from '$lib/api';
   import ConfirmDeleteDialog from '$lib/components/ConfirmDeleteDialog.svelte';
+  import { handleApiError } from '$lib/errorhandling/apiErrorHandling';
+  import { toast } from 'svelte-sonner';
 
   interface Props {
     open: boolean;
     user: AdminUsersView;
+    onDeleted?: () => void;
   }
 
-  let { open = $bindable<boolean>(), user }: Props = $props();
+  let { open = $bindable<boolean>(), user, onDeleted }: Props = $props();
+
+  function onDeleteClicked() {
+    adminDeleteUser({ path: { userId: user.id } })
+      .then(() => {
+        toast.success(`Deleted user ${user.name}`);
+        onDeleted?.();
+      })
+      .catch(handleApiError)
+      .finally(() => (open = false));
+  }
 </script>
 
-<ConfirmDeleteDialog bind:open title="Delete user" onConfirm={() => {}}>
+<ConfirmDeleteDialog bind:open title="Delete user" onConfirm={onDeleteClicked}>
   {#snippet description()}
     Are you sure you want to delete <strong>{user.name}</strong>?<br />
     All data associated with this user will be permanently deleted.<br />


### PR DESCRIPTION
The admin user delete confirmation dialog had a no-op onConfirm, so deleting a user did nothing. Wire it to adminDeleteUser with error handling and a success toast, and re-fetch the user list after a successful deletion. Export adminDeleteUser from the api barrel.