### PR TITLE
chore: remove leftover debug console.log statements

### DIFF
--- a/src/lib/signalr/handlers/DeviceUpdate.ts
+++ b/src/lib/signalr/handlers/DeviceUpdate.ts
@@ -1,4 +1,4 @@
-import { HubUpdateType, isHubUpdateType } from '$lib/signalr/models/HubUpdateType';
+import { isHubUpdateType } from '$lib/signalr/models/HubUpdateType';
 import { refreshOwnHubs } from '$lib/state/hubs-state.svelte';
 import { isString } from '$lib/typeguards';
 import { toast } from 'svelte-sonner';
@@ -9,10 +9,6 @@ export function handleSignalrDeviceUpdate(deviceId: unknown, updateType: unknown
     toast.error('Received invalid update from server!');
     return;
   }
-
-  const typeLabel = HubUpdateType[updateType];
-
-  console.log(`🔄 DeviceUpdate: ${deviceId} → ${typeLabel}`);
 
   refreshOwnHubs();
 }

--- a/src/routes/terminal/EspSerialConnection.ts
+++ b/src/routes/terminal/EspSerialConnection.ts
@@ -17,7 +17,6 @@ async function setupESPLoader(
     /* empty */
   }
 
-  console.log('setupESPLoader: ', serialPort);
   const transport = new Transport(serialPort);
 
   const flashOptions = {
@@ -75,8 +74,6 @@ async function setupApplication(serialPort: SerialPort): Promise<SerialPort> {
   } catch {
     /* empty */
   }
-
-  console.log('setupApplication: ', serialPort);
 
   try {
     // Need to connect to the ESP32 using the right settings.
@@ -310,7 +307,7 @@ export default class EspSerialConnection {
           }
         }
       } catch (e) {
-        console.log(e);
+        console.error(e);
         this.terminal.writeLine(`firmware disconnected: ${e}`);
       } finally {
         try {
@@ -347,11 +344,9 @@ export default class EspSerialConnection {
   }
 
   async disconnect() {
-    console.log('Disconnecting');
     await this._cycleTransport();
     this.serialPort = null;
     this.terminal.clean();
-    console.log('Disconnected');
   }
 
   async erase() {


### PR DESCRIPTION
Drop development tracing that shipped to production: the per-update DeviceUpdate log on every SignalR hub update, and setup/disconnect traces in the serial terminal connection. Promote a swallowed read-loop console.log to console.error.