### PR TITLE
fix(shockers): validate RF ID is a 16-bit integer

### DIFF
--- a/src/lib/components/ControlModules/dialogs/dialog-shocker-add.svelte
+++ b/src/lib/components/ControlModules/dialogs/dialog-shocker-add.svelte
@@ -26,6 +26,7 @@
   import { Field, FieldLabel } from '$lib/components/ui/field/index.js';
   import { Input } from '$lib/components/ui/input';
   import type { DialogContentProps } from '$lib/components/dialog-manager/types';
+  import { RfIdMax, RfIdMin, isValidRfId } from '$lib/constants/ShockerConstants';
   import type { OwnHub } from '$lib/state/hubs-state.svelte';
 
   interface Props extends DialogContentProps<NewShocker | undefined> {
@@ -38,7 +39,9 @@
   // svelte-ignore state_referenced_locally -- intentionally captures initial value as own reactive copy
   let data: AddShockerData = $state(initialData);
 
-  let canSubmit = $derived(data.name.trim().length > 0 && data.rfId > 0 && data.device.length > 0);
+  let canSubmit = $derived(
+    data.name.trim().length > 0 && isValidRfId(data.rfId) && data.device.length > 0
+  );
 
   function submit() {
     if (!canSubmit) return;
@@ -60,7 +63,14 @@
 
   <Field class="gap-2">
     <FieldLabel>RF ID</FieldLabel>
-    <Input type="number" placeholder="12345" bind:value={data.rfId} min={1} />
+    <Input
+      type="number"
+      placeholder="12345"
+      bind:value={data.rfId}
+      min={RfIdMin}
+      max={RfIdMax}
+      step={1}
+    />
   </Field>
 
   <Field class="gap-2">

--- a/src/lib/constants/ShockerConstants.ts
+++ b/src/lib/constants/ShockerConstants.ts
@@ -1,0 +1,8 @@
+/** RF transmit IDs are a 16-bit value (1–65535). */
+export const RfIdMin = 1;
+export const RfIdMax = 65535;
+
+/** Returns whether a value is a valid shocker RF transmit ID. */
+export function isValidRfId(value: number): boolean {
+  return Number.isInteger(value) && value >= RfIdMin && value <= RfIdMax;
+}

--- a/src/routes/(app)/shockers/[shockerId=guid]/edit/+page.svelte
+++ b/src/routes/(app)/shockers/[shockerId=guid]/edit/+page.svelte
@@ -11,6 +11,7 @@
   import { page } from '$app/state';
   import Container from '$lib/components/Container.svelte';
   import { dialog } from '$lib/components/dialog-manager/dialog-store.svelte';
+  import { RfIdMax, RfIdMin, isValidRfId } from '$lib/constants/ShockerConstants';
   import TextInput from '$lib/components/input/TextInput.svelte';
   import Button from '$lib/components/ui/button/button.svelte';
   import { Spinner } from '$lib/components/ui/spinner';
@@ -43,6 +44,8 @@
       (name.trim() !== shocker.name || rfId !== shocker.rfId || model !== shocker.model)
   );
 
+  let rfIdValid = $derived(isValidRfId(rfId));
+
   onMount(async () => {
     try {
       const shockerId = page.params.shockerId!;
@@ -58,7 +61,7 @@
   });
 
   async function save() {
-    if (!shocker || !name.trim()) return;
+    if (!shocker || !name.trim() || !rfIdValid) return;
     saving = true;
     try {
       await shockerEditShocker({
@@ -134,7 +137,12 @@
 
           <Field class="gap-2">
             <FieldLabel>RF ID</FieldLabel>
-            <Input type="number" bind:value={rfId} min={1} />
+            <Input type="number" bind:value={rfId} min={RfIdMin} max={RfIdMax} step={1} />
+            {#if !rfIdValid}
+              <span class="text-destructive text-sm">
+                RF ID must be a whole number between {RfIdMin} and {RfIdMax}.
+              </span>
+            {/if}
           </Field>
 
           <Field class="gap-2">
@@ -171,7 +179,7 @@
           </Field>
         </Card.Content>
         <Card.Footer>
-          <Button disabled={saving || !name.trim() || !hasChanges} onclick={save}>
+          <Button disabled={saving || !name.trim() || !rfIdValid || !hasChanges} onclick={save}>
             {#if saving}<Spinner class="size-4" />{/if}
             Save Changes
           </Button>


### PR DESCRIPTION
RF IDs are a 16-bit value (1-65535) but the add and edit forms only enforced
> 0, accepting decimals and out-of-range values. Add a shared
ShockerConstants helper (RfIdMin/RfIdMax/isValidRfId), enforce min/max/step on the inputs, gate submission on validity, and show an inline error on the edit page.