### PR TITLE
feat: react to pair-code consumption in hub pair dialog

### DIFF
--- a/src/lib/signalr/handlers/DeviceUpdate.ts
+++ b/src/lib/signalr/handlers/DeviceUpdate.ts
@@ -1,5 +1,5 @@
-import { isHubUpdateType } from '$lib/signalr/models/HubUpdateType';
-import { refreshOwnHubs } from '$lib/state/hubs-state.svelte';
+import { HubUpdateType, isHubUpdateType } from '$lib/signalr/models/HubUpdateType';
+import { notifyHubPaired, refreshOwnHubs } from '$lib/state/hubs-state.svelte';
 import { isString } from '@openshock/svelte-core/typeguards/index.js';
 import { toast } from 'svelte-sonner';
 
@@ -7,6 +7,12 @@ export function handleSignalrDeviceUpdate(deviceId: unknown, updateType: unknown
   if (!isString(deviceId) || !isHubUpdateType(updateType)) {
     console.error('Received invalid SignalR DeviceUpdate event', deviceId, updateType);
     toast.error('Received invalid update from server!');
+    return;
+  }
+
+  // Pairing doesn't change the hub list; just notify any open pair-code dialog.
+  if (updateType === HubUpdateType.HubPaired) {
+    notifyHubPaired(deviceId);
     return;
   }
 

--- a/src/lib/signalr/models/HubUpdateType.ts
+++ b/src/lib/signalr/models/HubUpdateType.ts
@@ -6,6 +6,8 @@ export enum HubUpdateType {
   HubDeleted = 3,
 
   HubShockersUpdate = 2,
+
+  HubPaired = 4,
 }
 
 export function isHubUpdateType(value: unknown): value is HubUpdateType {
@@ -16,6 +18,7 @@ export function isHubUpdateType(value: unknown): value is HubUpdateType {
       HubUpdateType.HubUpdated,
       HubUpdateType.HubDeleted,
       HubUpdateType.HubShockersUpdate,
+      HubUpdateType.HubPaired,
     ].includes(value)
   );
 }

--- a/src/lib/state/hubs-state.svelte.ts
+++ b/src/lib/state/hubs-state.svelte.ts
@@ -35,6 +35,14 @@ export class HubOnlineState {
 export const ownHubs = new SvelteMap<string, OwnHub>();
 export const onlineHubs = new SvelteMap<string, HubOnlineState>();
 
+// Incremented each time a hub consumes a pair code (DeviceUpdateType.Paired).
+// The pair-code dialog watches this to react once its displayed code is used.
+export const hubPairedSignals = new SvelteMap<string, number>();
+
+export function notifyHubPaired(hubId: string) {
+  hubPairedSignals.set(hubId, (hubPairedSignals.get(hubId) ?? 0) + 1);
+}
+
 export async function refreshOwnHubs() {
   try {
     const { data } = await shockerListShockers();

--- a/src/lib/state/hubs-state.svelte.ts
+++ b/src/lib/state/hubs-state.svelte.ts
@@ -35,7 +35,7 @@ export class HubOnlineState {
 export const ownHubs = new SvelteMap<string, OwnHub>();
 export const onlineHubs = new SvelteMap<string, HubOnlineState>();
 
-// Incremented each time a hub consumes a pair code (DeviceUpdateType.Paired).
+// Incremented each time a hub consumes a pair code (HubUpdateType.HubPaired).
 // The pair-code dialog watches this to react once its displayed code is used.
 export const hubPairedSignals = new SvelteMap<string, number>();
 

--- a/src/routes/(app)/hubs/data-table-actions.svelte
+++ b/src/routes/(app)/hubs/data-table-actions.svelte
@@ -20,9 +20,10 @@
   import { serializeCaptivePortalMessage } from '$lib/signalr/serializers/CaptivePortal';
   import { serializeEmergencyStopMessage } from '$lib/signalr/serializers/EmergencyStop';
   import { serializeRebootMessage } from '$lib/signalr/serializers/Reboot';
-  import { refreshOwnHubs } from '$lib/state/hubs-state.svelte';
+  import { hubPairedSignals, refreshOwnHubs } from '$lib/state/hubs-state.svelte';
   import { copyToClipboard } from '@openshock/svelte-core/utils/clipboard.svelte.js';
   import {
+    CircleCheck,
     Copy,
     KeyRound,
     Link,
@@ -79,8 +80,8 @@
   }
 
   async function openPairDialog() {
-    await dialog.open<{ loading: boolean; code: string | null }>({
-      data: { loading: false, code: null },
+    await dialog.open<{ loading: boolean; code: string | null; pairedBaseline: number }>({
+      data: { loading: false, code: null, pairedBaseline: 0 },
       contentSnippet: pairSnippet,
     });
   }
@@ -92,8 +93,14 @@
     });
   }
 
-  async function generatePairCode(data: { loading: boolean; code: string | null }) {
+  async function generatePairCode(data: {
+    loading: boolean;
+    code: string | null;
+    pairedBaseline: number;
+  }) {
     data.loading = true;
+    // Snapshot the paired counter so we only react to a consumption of *this* code.
+    data.pairedBaseline = hubPairedSignals.get(hub.id) ?? 0;
     try {
       const resp = await devicesGetPairCode({ path: { deviceId: hub.id } });
       data.code = resp.data;
@@ -134,18 +141,27 @@
   </div>
 {/snippet}
 
-{#snippet pairSnippet(props: DialogRenderProps<{ loading: boolean; code: string | null }>)}
+{#snippet pairSnippet(
+  props: DialogRenderProps<{ loading: boolean; code: string | null; pairedBaseline: number }>
+)}
+  {@const consumed =
+    !!props.data.code && (hubPairedSignals.get(hub.id) ?? 0) > props.data.pairedBaseline}
   <Dialog.Header>
     <Dialog.Title>
       {props.data.loading
         ? 'Generating...'
-        : props.data.code
-          ? 'Pair code generated'
-          : 'Generate pair code?'}
+        : consumed
+          ? 'Hub paired'
+          : props.data.code
+            ? 'Pair code generated'
+            : 'Generate pair code?'}
     </Dialog.Title>
     {#if !props.data.loading}
       <Dialog.Description>
-        {#if props.data.code}
+        {#if consumed}
+          <strong>{hub.name}</strong> consumed this pair code and is now paired.<br />
+          The code has been used and is no longer valid.
+        {:else if props.data.code}
           Pair code generated for <strong>{hub.name}</strong><br />
           The code below will not be accessible later, please copy it now and update clients with it
         {:else}
@@ -158,7 +174,13 @@
     {/if}
   </Dialog.Header>
   {#if !props.data.loading}
-    {#if props.data.code}
+    {#if consumed}
+      <div class="flex items-center gap-2 text-green-500">
+        <CircleCheck class="size-5" />
+        <span class="text-sm font-medium">Pairing complete</span>
+      </div>
+      <Button onclick={props.close}>Done</Button>
+    {:else if props.data.code}
       <div>
         <strong class="text-muted-foreground text-sm font-medium">Pair code:</strong>
         <CopyInput value={props.data.code} />


### PR DESCRIPTION
The hub pair-code dialog now reacts when its displayed code is consumed, showing a paired success state.

fixes #177

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/Frontend/pull/224">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->